### PR TITLE
Add a script for running the Docker E2E tests locally in a VM

### DIFF
--- a/docker_e2e_test/.gitignore
+++ b/docker_e2e_test/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 /bin
 /venv
+.vagrant
+testrun*.log

--- a/docker_e2e_test/Vagrantfile
+++ b/docker_e2e_test/Vagrantfile
@@ -21,8 +21,8 @@ Vagrant.configure("2") do |config|
       golang-docker-credential-helpers
 
     if ! [[ -f /usr/local/go/bin/go ]]; then
-      wget -q -P /tmp/ https://dl.google.com/go/go1.13.linux-amd64.tar.gz
-      tar -C /usr/local -xzf /tmp/go1.13.linux-amd64.tar.gz
+      wget -q -P /tmp/ https://dl.google.com/go/go1.15.5.linux-amd64.tar.gz
+      tar -C /usr/local -xzf /tmp/go1.15.5.linux-amd64.tar.gz
       echo 'PATH=${PATH}:/usr/local/go/bin' >> /home/vagrant/.bashrc
     fi
 

--- a/docker_e2e_test/Vagrantfile
+++ b/docker_e2e_test/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
     # Use the same specs that GitHub runners do
     # http://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
     vb.memory = "7168"
-    vb.cpus = 2
+    vb.cpus = 4
   end
 
   config.vm.provision "shell", inline: <<-SHELL

--- a/docker_e2e_test/Vagrantfile
+++ b/docker_e2e_test/Vagrantfile
@@ -1,0 +1,31 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrant config for running Autonity E2E tests
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+
+  config.vm.synced_folder "..", "/autonity"
+
+  config.vm.provider "virtualbox" do |vb|
+    # Use the same specs that GitHub runners do
+    # http://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
+    vb.memory = "7168"
+    vb.cpus = 2
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get -y install make docker.io python3 python3-venv python3-pip \
+      golang-docker-credential-helpers
+
+    if ! [[ -f /usr/local/go/bin/go ]]; then
+      wget -q -P /tmp/ https://dl.google.com/go/go1.13.linux-amd64.tar.gz
+      tar -C /usr/local -xzf /tmp/go1.13.linux-amd64.tar.gz
+      echo 'PATH=${PATH}:/usr/local/go/bin' >> /home/vagrant/.bashrc
+    fi
+
+    pip3 install -r /autonity/docker_e2e_test/requirements_docker_test.txt
+  SHELL
+end

--- a/docker_e2e_test/run-tests-in-vm
+++ b/docker_e2e_test/run-tests-in-vm
@@ -1,0 +1,19 @@
+#!/bin/bash -u
+
+# Run Autonity E2E tests locally.
+# Dependencies: vagrant, virtualbox
+
+readonly CMD="$(cat <<-EOF
+	cd /autonity &&
+	make all &&
+	cd docker_e2e_test &&
+	make docker-e2e-tests
+	EOF
+)"
+readonly LOGFILE="testrun-$(date -Iseconds).log"
+
+cd "$(dirname "$0")" &&
+vagrant up --provider virtualbox &&
+trap 'vagrant suspend' EXIT &&
+vagrant ssh -c "bash -i -c '${CMD}'" 2>&1 | tee "${LOGFILE}"
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
The Docker end-to-end tests for Autonity were primarily designed to be
executed in a CI system like GitHub Actions, however it can sometimes be
beneficial to run them locally for retesting or analysis.

As the tests are executed with superuser privileges, they could be
dangerous to run on a workstation. Also, because they are assumed to
run in Ubuntu, they could be fiddly to set up on any other system.

This pull request adds a Vagrantfile for setting up an Ubuntu virtual machine
and a shell script for running the tests inside the VM.