### PR TITLE
change snap protocol name

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,7 +70,7 @@ jobs:
         # excluding packages of particular interest. The excluded package are
         # those that are slow to test, our e2e tests and tendermint core.
         tests: [ [ main-tests, $(go list ./... | grep -E -v "/les|/p2p|/eth|/consensus/tendermint|/consensus/test|/core$|/e2e_test") ],
-                 [ slow-tests, $(go list ./p2p/... ./eth/... | grep -E -v "/p2p/simulations") -timeout 20m ],
+                 [ slow-tests, $(go list ./p2p/... ./eth/... | grep -E -v "/p2p/simulations") -timeout 30m ],
                  [ problematic-tests, -p 1 ./p2p/simulations/... ./core ],
                  [ tendermint-tests, ./consensus/tendermint/... -timeout 15m -race ],
                  [ integration-tests, ./consensus/test/... -v -timeout 60m ],

--- a/cmd/devp2p/internal/ethtest/helpers.go
+++ b/cmd/devp2p/internal/ethtest/helpers.go
@@ -104,7 +104,7 @@ func (s *Suite) dialSnap() (*Conn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dial failed: %v", err)
 	}
-	conn.caps = append(conn.caps, p2p.Cap{Name: "snap", Version: 1})
+	conn.caps = append(conn.caps, p2p.Cap{Name: "aut-snap", Version: 1})
 	conn.ourHighestSnapProtoVersion = 1
 	return conn, nil
 }

--- a/consensus/tendermint/core/upon_condition_test.go
+++ b/consensus/tendermint/core/upon_condition_test.go
@@ -1226,7 +1226,7 @@ func TestQuorumPrecommit(t *testing.T) {
 	clientAddr := members[0].Address
 	currentHeight := big.NewInt(int64(rand.Intn(maxSize+1) + 1))
 	nextHeight := currentHeight.Uint64() + 1
-
+	t.Log("committee size", committeeSizeAndMaxRound, "current height", currentHeight)
 	nextProposalMsg, nextP := generateBlockProposal(t, 0, big.NewInt(int64(nextHeight)), int64(-1), clientAddr, false, privateKeys[clientAddr])
 
 	currentRound := int64(rand.Intn(committeeSizeAndMaxRound))
@@ -1266,10 +1266,12 @@ func TestQuorumPrecommit(t *testing.T) {
 
 	// if the client is the next proposer
 	if newCommitteeSet.GetProposer(0).Address == clientAddr {
+		t.Log("is proposer")
+
 		c.pendingCandidateBlocks[nextHeight] = nextP.ProposalBlock
 		backendMock.EXPECT().SetProposedBlockHash(nextP.ProposalBlock.Hash())
 
-		backendMock.EXPECT().Sign(nextProposalMsg.Bytes).Return(nextProposalMsg.Signature, nil)
+		backendMock.EXPECT().Sign(gomock.Any()).AnyTimes().DoAndReturn(signer(privateKeys[clientAddr]))
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), nextProposalMsg.Bytes).Return(nil)
 	}
 

--- a/eth/protocols/snap/protocol.go
+++ b/eth/protocols/snap/protocol.go
@@ -32,7 +32,7 @@ const (
 
 // ProtocolName is the official short name of the `snap` protocol used during
 // devp2p capability negotiation.
-const ProtocolName = "snap"
+const ProtocolName = "aut-snap"
 
 // ProtocolVersions are the supported versions of the `snap` protocol (first
 // is primary).

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -51,7 +51,7 @@ func testSnapSyncDisabling(t *testing.T, ethVer uint, snapVer uint) {
 	defer full.close()
 
 	// Sync up the two handlers via both `eth` and `snap`
-	caps := []p2p.Cap{{Name: "aut", Version: ethVer}, {Name: "snap", Version: snapVer}}
+	caps := []p2p.Cap{{Name: "aut", Version: ethVer}, {Name: "aut-snap", Version: snapVer}}
 
 	emptyPipeEth, fullPipeEth := p2p.MsgPipe()
 	defer emptyPipeEth.Close()


### PR DESCRIPTION
closes https://github.com/autonity/autonity/issues/791
Change the snap protocol name to `aut-snap` in order to avoid matching eth mainnet nodes during devp2p capability negotiation.
