### PR TITLE
fix oracle contract voter sort

### DIFF
--- a/autonity/solidity/contracts/Oracle.sol
+++ b/autonity/solidity/contracts/Oracle.sol
@@ -280,14 +280,13 @@ contract Oracle is IOracle {
     */
     function _votersSort(address[] memory _voters, int _low, int _high)
     internal pure {
+        if (_low >= _high) return;
         int _i = _low;
         int _j = _high;
-        if (_i == _j) return;
         address _pivot = _voters[uint(_low + (_high - _low) / 2)];
-        // Set the pivot element in its right sorted index in the array
         while (_i <= _j) {
-            while (_voters[uint(_i)] > _pivot) _i++;
-            while (_pivot > _voters[uint(_j)]) _j--;
+            while (_voters[uint(_i)] < _pivot) _i++;
+            while (_voters[uint(_j)] > _pivot) _j--;
             if (_i <= _j) {
                 (_voters[uint(_i)], _voters[uint(_j)]) =
                 (_voters[uint(_j)], _voters[uint(_i)]);

--- a/autonity/solidity/test/oracle.js
+++ b/autonity/solidity/test/oracle.js
@@ -187,7 +187,12 @@ contract("Oracle", accounts => {
 
     it('Test get committee', async function () {
       let vs = await oracle.getVoters();
-      assert.deepEqual(voterAccounts.slice().sort(), vs.slice().sort(), "symbols are not as expected");
+      assert.deepEqual(
+        voterAccounts.slice().sort(function (a, b) {
+          return a.toLowerCase().localeCompare(b.toLowerCase());
+        }),
+        vs, "voters are not as expected"
+      );
     });
 
     it('Test get round', async function () {
@@ -197,6 +202,25 @@ contract("Oracle", accounts => {
   });
 
   describe('Contract set api test', function() {
+    it('Test sorting of voters', async function () {
+      let newVoters = [
+        "0xfF00000000000000000000000000000000000000",
+        "0xaa00000000000000000000000000000000000000",
+        "0x1100000000000000000000000000000000000000",
+        "0x6600000000000000000000000000000000000000",
+        "0xd228247B4f57587F6d2A479669e277699643135B",
+        "0xF7cA6855Df4B0f725aC0dA6B54DD5CDF7E4c21d8",
+      ]
+      await oracle.setVoters(newVoters, {from:autonity});
+      let updatedVoters = await oracle.getVoters();
+      //console.log(updatedVoters)
+      assert.deepEqual(
+        newVoters.slice().sort(function (a, b) {
+          return a.toLowerCase().localeCompare(b.toLowerCase());
+        }),
+        updatedVoters, "voters are not as expected"
+      );
+    });
     it('Test update voters', async function () {
       let newVoters = [
         accounts[0],
@@ -207,6 +231,12 @@ contract("Oracle", accounts => {
       await oracle.setVoters(newVoters, {from:autonity});
       let updatedVoters = await oracle.getVoters();
       assert.deepEqual(newVoters.slice().sort(), updatedVoters.slice().sort(), "voters are not as expected");
+      assert.deepEqual(
+        newVoters.slice().sort(function (a, b) {
+          return a.toLowerCase().localeCompare(b.toLowerCase());
+        }),
+        updatedVoters, "voters are not as expected"
+      );
     });
     it('Test update voters - empty voter list', async function () {
       let newVoters = [];


### PR DESCRIPTION
The oracle contract `_votersSort` function sorts the voters in descending address order, but the `_updateVotingInfo` function expects them sorted in ascending order. This PR fixes the sorting algo to sort ascending and adds some tests for it.

Tests were not failing before because the addresses generated by the truffle contract tests were not hitting this edge case.
