### PR TITLE
Oracle vote tip refund

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -355,10 +355,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		if oracleVote {
 			// Refund tx Fee, if this is a successful vote transaction
 			gasUsed := new(big.Int).SetUint64(st.gasUsed())
-			fee := new(big.Int).Mul(st.evm.Context.BaseFee, gasUsed)
+			fee := new(big.Int).Mul(st.gasPrice, gasUsed)
 			st.state.AddBalance(st.msg.From(), fee)
-			//fmt.Println("Refunding Used Fee:", fee, " Base Fee:",
-			//st.evm.Context.BaseFee, " Gas used:", gasUsed, " gasPrice:", st.gasPrice)
 		}
 	}
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 0          // Major version component of the current release
-	VersionMinor = 11         // Minor version component of the current release
-	VersionPatch = 0          // Patch version component of the current release
-	VersionMeta  = "internal" // Version metadata to append to the version string
+	VersionMajor = 0  // Major version component of the current release
+	VersionMinor = 12 // Minor version component of the current release
+	VersionPatch = 0  // Patch version component of the current release
+	VersionMeta  = "" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.
@@ -43,7 +43,8 @@ var VersionWithMeta = func() string {
 
 // ArchiveVersion holds the textual version string used for Autonity archives.
 // e.g. "1.8.11-dea1ce05" for stable releases, or
-//      "1.8.13-unstable-21c059b6" for unstable releases
+//
+//	"1.8.13-unstable-21c059b6" for unstable releases
 func ArchiveVersion(gitCommit string) string {
 	vsn := Version
 	if VersionMeta != "stable" {


### PR DESCRIPTION
Refund whole transaction fee (basefee + effective tip) for a successful oracle vote transaction.
This is necessary to handle vote transactions with non-0 tips.