### PR TITLE
Fix autonity unbonding

### DIFF
--- a/autonity/solidity/contracts/Autonity.sol
+++ b/autonity/solidity/contracts/Autonity.sol
@@ -321,8 +321,6 @@ contract Autonity is IAutonity, IERC20, Upgradeable {
     */
     function unbond(address _validator, uint256 _amount) public {
         require(validators[_validator].nodeAddress == _validator, "validator not registered");
-        // in case _amount = 0, it is harmless, yet can trigger contract to fail in end-epoch phase
-        // in some limited case
         require(_amount > 0, "unbonding amount is 0");
         _unbond(_validator, _amount, payable(msg.sender));
     }

--- a/autonity/solidity/contracts/Autonity.sol
+++ b/autonity/solidity/contracts/Autonity.sol
@@ -321,6 +321,9 @@ contract Autonity is IAutonity, IERC20, Upgradeable {
     */
     function unbond(address _validator, uint256 _amount) public {
         require(validators[_validator].nodeAddress == _validator, "validator not registered");
+        // in case _amount = 0, it is harmless, yet can trigger contract to fail in end-epoch phase
+        // in some limited case
+        require(_amount > 0, "unbonding amount is 0");
         _unbond(_validator, _amount, payable(msg.sender));
     }
 
@@ -1142,6 +1145,8 @@ contract Autonity is IAutonity, IERC20, Upgradeable {
             }
             _validator.selfUnbondingStake += _newtonAmount;
             _validator.selfUnbondingShares += _unbonding.unbondingShare;
+            // decrease _validator.selfBondedStake for self-delegation
+            _validator.selfBondedStake -= _newtonAmount;
         }
 
         _unbonding.unlocked = true;

--- a/autonity/solidity/test/autonity.js
+++ b/autonity/solidity/test/autonity.js
@@ -929,6 +929,20 @@ contract('Autonity', function (accounts) {
       */
     });
     
+    it("non-self-unbond 0 amount without bonding first, and trigger end-epoch", async function() {
+      const newAccount = accounts[8];
+      const validator = validators[0].nodeAddress;
+      // should fail
+      await truffleAssert.fails(
+        autonity.unbond(validator, 0, {from: newAccount}),
+        truffleAssert.ErrorType.REVERT,
+        "unbonding amount is 0"
+      );
+      // if the tx above is not failed, then triggering end-epoch will fail
+      // and autonity contract will not be able to end epoch
+      await endEpoch(autonity, operator, deployer);
+    });
+    
     // TODO(lorenzo) the internal queues for bond and unbond are not accessible anymore.
     // if we want to keep this test we need another contract that inherits autonity and exposes these fields
     it.skip('test bonding queue logic', async function () {


### PR DESCRIPTION
Fixed 2 bugs:
- `_validator.selfBondedStake` should decrease in case of self-unbonding at `_applyUnbonding`
- In case of non-self-unbonding-request with `amount = 0` and no prior delegation, the unbonding-request still registers into unbonding-map. As a result, at `_applyUnbonding` in epoch-end, `_newtonAmount` is calculated assuming total `_validator.liquidSupply` is positive and gets error because of division by 0. In case this error is triggered, epoch is never progressed.