### PR TITLE
Make Solidity licenses consistent with repo

### DIFF
--- a/autonity/solidity/contracts/Accountability.sol
+++ b/autonity/solidity/contracts/Accountability.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
 import "./interfaces/IAccountability.sol";

--- a/autonity/solidity/contracts/Autonity.sol
+++ b/autonity/solidity/contracts/Autonity.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.19;
 

--- a/autonity/solidity/contracts/Autonity.sol
+++ b/autonity/solidity/contracts/Autonity.sol
@@ -77,7 +77,7 @@ contract Autonity is IAutonity, IERC20, Upgradeable {
     uint256 internal headUnbondingID;
     uint256 internal lastUnlockedUnbonding;
 
-    /* Used to track commission rate change - See ADR-002 */
+    /* Used to track commission rate change*/
     struct CommissionRateChangeRequest {
         address validator;
         uint256 startBlock;
@@ -325,7 +325,7 @@ contract Autonity is IAutonity, IERC20, Upgradeable {
     }
 
     /**
-    * @notice Pause the validator and stop it accepting delegations. See ADR-004 for more details.
+    * @notice Pause the validator and stop it accepting delegations.
     * @param _address address to be disabled.
     * @dev emit a {DisabledValidator} event.
     */
@@ -336,7 +336,7 @@ contract Autonity is IAutonity, IERC20, Upgradeable {
     }
 
     /**
-    * @notice Re-activate the specified validator. See ADR-004 for more details.
+    * @notice Re-activate the specified validator.
     * @param _address address to be enabled.
     */
     function activateValidator(address _address) public {
@@ -363,7 +363,7 @@ contract Autonity is IAutonity, IERC20, Upgradeable {
     }
 
     /**
-    * @notice Change commission rate for the specified validator. See ADR-002 for more details.
+    * @notice Change commission rate for the specified validator.
     * @param _validator address to be enabled.
             _rate new commission rate, ranging between 0-10000 (10000 = 100%).
     */

--- a/autonity/solidity/contracts/AutonityTest.sol
+++ b/autonity/solidity/contracts/AutonityTest.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.3;
 

--- a/autonity/solidity/contracts/AutonityUpgradeTest.sol
+++ b/autonity/solidity/contracts/AutonityUpgradeTest.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.3;
 

--- a/autonity/solidity/contracts/Helpers.sol
+++ b/autonity/solidity/contracts/Helpers.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.3;
 

--- a/autonity/solidity/contracts/Liquid.sol
+++ b/autonity/solidity/contracts/Liquid.sol
@@ -1,6 +1,4 @@
-// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
-//
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.3;
 import "./interfaces/IERC20.sol";

--- a/autonity/solidity/contracts/Migrations.sol
+++ b/autonity/solidity/contracts/Migrations.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.4.21;
 
 contract Migrations {

--- a/autonity/solidity/contracts/MockEnodeVerifier.sol
+++ b/autonity/solidity/contracts/MockEnodeVerifier.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
 contract MockEnodeVerifier {

--- a/autonity/solidity/contracts/Oracle.sol
+++ b/autonity/solidity/contracts/Oracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.2 < 0.9.0;
 
 import "./interfaces/IOracle.sol";

--- a/autonity/solidity/contracts/Precompiled.sol
+++ b/autonity/solidity/contracts/Precompiled.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.3;
 

--- a/autonity/solidity/contracts/SafeMath.sol
+++ b/autonity/solidity/contracts/SafeMath.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.3;
 
 /**

--- a/autonity/solidity/contracts/Upgradeable.sol
+++ b/autonity/solidity/contracts/Upgradeable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.3;
 

--- a/autonity/solidity/contracts/asm/ACU.sol
+++ b/autonity/solidity/contracts/asm/ACU.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
 /*

--- a/autonity/solidity/contracts/asm/IACU.sol
+++ b/autonity/solidity/contracts/asm/IACU.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
 /*

--- a/autonity/solidity/contracts/asm/IStabilization.sol
+++ b/autonity/solidity/contracts/asm/IStabilization.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
 /*

--- a/autonity/solidity/contracts/asm/ISupplyControl.sol
+++ b/autonity/solidity/contracts/asm/ISupplyControl.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
 /*

--- a/autonity/solidity/contracts/asm/Stabilization.sol
+++ b/autonity/solidity/contracts/asm/Stabilization.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
 /*

--- a/autonity/solidity/contracts/asm/SupplyControl.sol
+++ b/autonity/solidity/contracts/asm/SupplyControl.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
 /*

--- a/autonity/solidity/contracts/bindings.sol
+++ b/autonity/solidity/contracts/bindings.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.3;
 

--- a/autonity/solidity/contracts/interfaces/IAccountability.sol
+++ b/autonity/solidity/contracts/interfaces/IAccountability.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
 interface IAccountability {

--- a/autonity/solidity/contracts/interfaces/IAutonity.sol
+++ b/autonity/solidity/contracts/interfaces/IAutonity.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 /**
  * @dev Interface of the Autonity Contract.

--- a/autonity/solidity/contracts/interfaces/IERC20.sol
+++ b/autonity/solidity/contracts/interfaces/IERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: LGPL-3.0-only
 
 pragma solidity ^0.8.3;
 

--- a/autonity/solidity/contracts/interfaces/IOracle.sol
+++ b/autonity/solidity/contracts/interfaces/IOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.2 < 0.9.0;
 /**
  * @dev Interface of the Oracle Contract


### PR DESCRIPTION
Make the license for Solidity code match the same LGPLv3 license of the repository itself. Also, some references to internal docs are removed.