### PR TITLE
Add NTN-ATN to OracleInitialSymbols

### DIFF
--- a/autonity/solidity/test/asm/test_acu.py
+++ b/autonity/solidity/test/asm/test_acu.py
@@ -220,8 +220,8 @@ def test_modify_basket(acu_basic, users):
     assert len(receipt.events) == 1
     event = receipt.events[0]
     assert event.event_name == "BasketModified"
-    assert event.symbols == tuple(new_basket)
-    assert event.quantities == tuple(new_quantities)
+    assert event.symbols[0] == new_basket
+    assert event.quantities[0] == new_quantities
     assert event.scale == new_scale
 
 

--- a/params/protocol_contracts.go
+++ b/params/protocol_contracts.go
@@ -20,7 +20,7 @@ var (
 
 	//Oracle Contract defaults
 	OracleVotePeriod           = uint64(30)
-	OracleInitialSymbols       = []string{"AUD-USD", "CAD-USD", "EUR-USD", "GBP-USD", "JPY-USD", "SEK-USD", "ATN-USD", "NTN-USD"}
+	OracleInitialSymbols       = []string{"AUD-USD", "CAD-USD", "EUR-USD", "GBP-USD", "JPY-USD", "SEK-USD", "ATN-USD", "NTN-USD", "NTN-ATN"}
 	DefaultGenesisOracleConfig = &OracleContractGenesis{
 		Bytecode:   generated.OracleBytecode,
 		ABI:        &generated.OracleAbi,


### PR DESCRIPTION
The NTN-ATN price is needed for Stabilization.