### PR TITLE
Fix failing ASM ACU contract test

### DIFF
--- a/autonity/solidity/test/asm/test_acu.py
+++ b/autonity/solidity/test/asm/test_acu.py
@@ -220,8 +220,8 @@ def test_modify_basket(acu_basic, users):
     assert len(receipt.events) == 1
     event = receipt.events[0]
     assert event.event_name == "BasketModified"
-    assert event.symbols[0] == new_basket
-    assert event.quantities[0] == new_quantities
+    assert event.symbols == tuple(new_basket)
+    assert event.quantities == tuple(new_quantities)
     assert event.scale == new_scale
 
 


### PR DESCRIPTION
This reverts commit 261960b68de745d532c83b2b38dcc691fa29ab19, which does not seem to be correct.