### PR TITLE
pin ape-solidity plugin version to 0.6.9

### DIFF
--- a/autonity/solidity/ape-config.yaml
+++ b/autonity/solidity/ape-config.yaml
@@ -4,7 +4,7 @@ contracts_folder: contracts
 
 plugins:
   - name: hardhat
-  - name: solidity
+  - name: solidity==0.6.9
 
 # Ignore `bindings.sol` to speed up compilation. This is because compiling it
 # doesn't result in a cached JSON file under `.build/`, and so it must be

--- a/autonity/solidity/ape-config.yaml
+++ b/autonity/solidity/ape-config.yaml
@@ -3,7 +3,7 @@
 contracts_folder: contracts
 
 plugins:
-  - name: hardhat
+  - name: hardhat==0.6.13
   - name: solidity==0.6.9
 
 # Ignore `bindings.sol` to speed up compilation. This is because compiling it


### PR DESCRIPTION
Version 0.6.10 of ape-solidity requires eth-ape version >=0.6.25, which causes issues for us (see https://github.com/autonity/autonity/issues/850). 

Due to this ACU tests [were failing again](https://github.com/autonity/autonity/actions/runs/6875042982/job/18700681721?pr=855). This version pinning solves the issue. 