### PR TITLE
fix invalid metric due to hyphen in protocol name

### DIFF
--- a/cmd/devp2p/internal/ethtest/helpers.go
+++ b/cmd/devp2p/internal/ethtest/helpers.go
@@ -104,7 +104,7 @@ func (s *Suite) dialSnap() (*Conn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dial failed: %v", err)
 	}
-	conn.caps = append(conn.caps, p2p.Cap{Name: "aut-snap", Version: 1})
+	conn.caps = append(conn.caps, p2p.Cap{Name: "aut_snap", Version: 1})
 	conn.ourHighestSnapProtoVersion = 1
 	return conn, nil
 }

--- a/eth/protocols/snap/protocol.go
+++ b/eth/protocols/snap/protocol.go
@@ -32,7 +32,7 @@ const (
 
 // ProtocolName is the official short name of the `snap` protocol used during
 // devp2p capability negotiation.
-const ProtocolName = "aut-snap"
+const ProtocolName = "aut_snap"
 
 // ProtocolVersions are the supported versions of the `snap` protocol (first
 // is primary).

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -51,7 +51,7 @@ func testSnapSyncDisabling(t *testing.T, ethVer uint, snapVer uint) {
 	defer full.close()
 
 	// Sync up the two handlers via both `eth` and `snap`
-	caps := []p2p.Cap{{Name: "aut", Version: ethVer}, {Name: "aut-snap", Version: snapVer}}
+	caps := []p2p.Cap{{Name: "aut", Version: ethVer}, {Name: snap.ProtocolName, Version: snapVer}}
 
 	emptyPipeEth, fullPipeEth := p2p.MsgPipe()
 	defer emptyPipeEth.Close()

--- a/metrics/buffered_gauge.go
+++ b/metrics/buffered_gauge.go
@@ -38,10 +38,12 @@ func GetOrRegisterBufferedGauge(name string, r Registry) BufferedGauge {
 
 // NewBufferedGauge constructs a new BufferedGauge.
 func NewBufferedGauge() BufferedGauge {
-	if !Enabled {
-		return NilBufferedGauge{}
-	}
-	return &StandardBufferedGauge{values: make([]GaugeValue, 0, BufferedGaugeCapacity)}
+	//TODO: isn't supported in prometheus, fix later
+	return NilBufferedGauge{}
+	//if !Enabled {
+	//	return NilBufferedGauge{}
+	//}
+	//return &StandardBufferedGauge{values: make([]GaugeValue, 0, BufferedGaugeCapacity)}
 }
 
 // NewRegisteredBufferedGauge constructs and registers a new StandardBufferedGauge.

--- a/metrics/exp/exp.go
+++ b/metrics/exp/exp.go
@@ -169,6 +169,8 @@ func (exp *exp) syncToExpvar() {
 			exp.publishCounter(name, i)
 		case metrics.Gauge:
 			exp.publishGauge(name, i)
+		case metrics.BufferedGauge:
+			//TODO:
 		case metrics.GaugeFloat64:
 			exp.publishGaugeFloat64(name, i)
 		case metrics.Histogram:

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -47,6 +47,10 @@ func Handler(reg metrics.Registry) http.Handler {
 				c.addCounter(name, m.Snapshot())
 			case metrics.Gauge:
 				c.addGauge(name, m.Snapshot())
+			case metrics.BufferedGauge:
+				// clear buffered to avoid growing the memory, ignore adding to the collector for now
+				m.SnapshotAndClear()
+				// TODO: need to add support for bufferedGauge to correct prometheus type
 			case metrics.GaugeFloat64:
 				c.addGaugeFloat64(name, m.Snapshot())
 			case metrics.Histogram:

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -48,8 +48,6 @@ func Handler(reg metrics.Registry) http.Handler {
 			case metrics.Gauge:
 				c.addGauge(name, m.Snapshot())
 			case metrics.BufferedGauge:
-				// clear buffered to avoid growing the memory, ignore adding to the collector for now
-				m.SnapshotAndClear()
 				// TODO: need to add support for bufferedGauge to correct prometheus type
 			case metrics.GaugeFloat64:
 				c.addGaugeFloat64(name, m.Snapshot())


### PR DESCRIPTION
fix invalid metric due to hyphen in protocol name
Avoid warnings on buffered gauge on prometheus scrapping.
