### PR TITLE
start consensus only after syncing with the network

### DIFF
--- a/autonity/solidity/test/autonity/autonity-start.sh
+++ b/autonity/solidity/test/autonity/autonity-start.sh
@@ -39,5 +39,6 @@ if [ $? -ne 0 ]; then
     --allow-insecure-unlock \
     --unlock 0x850c1eb8d190e05845ad7f84ac95a318c8aab07f,0x4ad219b58a5b46a1d9662beaa6a70db9f570dea5,0x4b07239bd581d21aefcdee0c6db38070f9a5fd2d,0xc443c6c6ae98f5110702921138d840e77da67702,0x09428e8674496e2d1e965402f33a9520c5fcbbe2,0x64852003fc0b84d6c49c5cb3dfcd17922affddc1,0x4839950a5f07d6d6cd82f933d1de8574c48d6e74,0x160bc705bf2e5871557722c9332cfa185c02b765,0xe12b43B69E57eD6ACdd8721Eb092BF7c8D41Df41,0xDE03B7806f885Ae79d2aa56568b77caDB0de073E \
     --password password \
-    --miner.threads 1 
+    --miner.threads 1 \
+    --mine
 fi

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -405,7 +405,7 @@ var (
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{
 		Name:  "mine",
-		Usage: "Enable mining",
+		Usage: "Enable mining. Will bypass the chain sync check.",
 	}
 	MinerThreadsFlag = cli.IntFlag{
 		Name:  "miner.threads",

--- a/consensus/tendermint/accountability/reporter.go
+++ b/consensus/tendermint/accountability/reporter.go
@@ -3,9 +3,10 @@ package accountability
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/autonity/autonity/autonity"
 	"github.com/autonity/autonity/common"
-	"time"
 )
 
 const (
@@ -68,7 +69,7 @@ func (fd *FaultDetector) tryReport(ev *autonity.AccountabilityEvent) error {
 			return errPendingReport
 		}
 	}
-	fd.logger.Warn("Reporting faulty validator", "offender", ev.Offender, "rule", ev.Rule, "block", ev.Block)
+	fd.logger.Warn("Reporting faulty validator", "offender", ev.Offender, "rule", autonity.Rule(ev.Rule).String(), "block", ev.Block)
 	fd.eventReporterCh <- ev
 	return nil
 }

--- a/consensus/test/auto_mining_test.go
+++ b/consensus/test/auto_mining_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/autonity/autonity/core"
 	"github.com/autonity/autonity/core/types"
 	"github.com/autonity/autonity/crypto"
 	"github.com/autonity/autonity/ethclient"
-	"github.com/stretchr/testify/require"
 )
 
 // test committee members should all start the mining workers.

--- a/consensus/test/test_helpers_test.go
+++ b/consensus/test/test_helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/autonity/autonity/crypto/blst"
 	"math"
 	"math/big"
 	"os"
@@ -14,9 +13,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/autonity/autonity/core"
 	"github.com/autonity/autonity/core/types"
 	"github.com/autonity/autonity/crypto"
+	"github.com/autonity/autonity/crypto/blst"
 	"github.com/autonity/autonity/eth/downloader"
 	"github.com/autonity/autonity/eth/ethconfig"
 	"github.com/autonity/autonity/log"
@@ -24,8 +27,6 @@ import (
 	"github.com/autonity/autonity/node"
 	"github.com/autonity/autonity/p2p"
 	"github.com/autonity/autonity/params"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 )
 
 const defaultStake = 100
@@ -93,8 +94,8 @@ func makeNodeConfig(t *testing.T, genesis *core.Genesis, nodekey *ecdsa.PrivateK
 		P2P: p2p.Config{
 			ListenAddr:  listenAddr,
 			NoDiscovery: true,
-			MaxPeers:    25,
 			PrivateKey:  nodekey,
+			MaxPeers:    25,
 		},
 	}
 	nodeConfig.HTTPHost = "127.0.0.1"

--- a/consensus/test/testcase_test.go
+++ b/consensus/test/testcase_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"github.com/autonity/autonity/crypto/blst"
 	"net"
 	"os"
 	"strconv"
@@ -13,19 +12,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
+	"go.uber.org/goleak"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/autonity/autonity/common/fdlimit"
 	"github.com/autonity/autonity/common/graph"
 	"github.com/autonity/autonity/common/keygenerator"
 	"github.com/autonity/autonity/core"
 	"github.com/autonity/autonity/core/types"
 	"github.com/autonity/autonity/crypto"
+	"github.com/autonity/autonity/crypto/blst"
 	"github.com/autonity/autonity/log"
 	"github.com/autonity/autonity/metrics"
 	"github.com/autonity/autonity/p2p"
 	"github.com/autonity/autonity/p2p/enode"
-	"github.com/davecgh/go-spew/spew"
-	"go.uber.org/goleak"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -160,7 +161,8 @@ func runTest(t *testing.T, test *testCase) {
 			peer.rpcPort, rates.in, rates.out)
 
 		wg.Go(func() error {
-			return peer.startNode()
+			// if we have only a single validator, force mining start to bypass sync check
+			return peer.startNode(nodesNum == 1)
 		})
 	}
 

--- a/consensus/test/testnode_test.go
+++ b/consensus/test/testnode_test.go
@@ -3,13 +3,13 @@ package test
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/autonity/autonity/crypto/blst"
 	"net"
 	"sync"
 
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/core"
 	"github.com/autonity/autonity/crypto"
+	"github.com/autonity/autonity/crypto/blst"
 	"github.com/autonity/autonity/eth"
 	"github.com/autonity/autonity/event"
 	"github.com/autonity/autonity/node"
@@ -60,7 +60,7 @@ type block struct {
 	txs  int
 }
 
-func (validator *testNode) startNode() error {
+func (validator *testNode) startNode(forceMining bool) error {
 	// Start the node and configure a full Ethereum node on it
 	var err error
 	validator.node, err = node.New(validator.nodeConfig)
@@ -75,6 +75,10 @@ func (validator *testNode) startNode() error {
 
 	if err := validator.node.Start(); err != nil {
 		return fmt.Errorf("cannot start a node %s", err)
+	}
+
+	if forceMining {
+		validator.service.StartMining(0)
 	}
 
 	// Start tracking the node and it's enode

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -80,7 +80,7 @@ func TestProtocolContractsDeployment(t *testing.T) {
 	upgradeManagerAutonityAddress, err := upgradeManagerContract.Autonity(nil)
 	require.NoError(t, err)
 	require.Equal(t, params.AutonityContractAddress, upgradeManagerAutonityAddress)
-	err = network.WaitToMineNBlocks(2, 10, false)
+	err = network.WaitToMineNBlocks(2, 15, false)
 	require.NoError(t, err)
 }
 

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/autonity/autonity/accounts/abi/bind"
 	"github.com/autonity/autonity/autonity"
 	"github.com/autonity/autonity/common"
+	"github.com/autonity/autonity/consensus/tendermint/core"
+	"github.com/autonity/autonity/consensus/tendermint/core/interfaces"
+	"github.com/autonity/autonity/consensus/tendermint/core/message"
 	"github.com/autonity/autonity/params"
 )
 
@@ -217,7 +220,7 @@ func TestStartingAndStoppingNodes(t *testing.T) {
 	err = n.SendAUTtracked(ctx, network[1].Address, 10)
 	require.NoError(t, err)
 	// Stop a node
-	err = network[1].Close()
+	err = network[1].Close(true)
 	network[1].Wait()
 	require.NoError(t, err)
 	// Send a tx to see that the network is working
@@ -227,7 +230,7 @@ func TestStartingAndStoppingNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stop a node
-	err = network[2].Close()
+	err = network[2].Close(true)
 	network[2].Wait()
 	require.NoError(t, err)
 	// We have now stopped more than F nodes, so we expect tx processing to time out.
@@ -260,6 +263,75 @@ func TestStartingAndStoppingNodes(t *testing.T) {
 	// Send a tx to see that the network is still working
 	err = n.SendAUTtracked(context.Background(), network[1].Address, 10)
 	require.NoError(t, err)
+}
+
+func NewBroadcasterWithCheck(currentHeight uint64, stopped bool) func(c interfaces.Core) interfaces.Broadcaster {
+	return func(c interfaces.Core) interfaces.Broadcaster {
+		return &broadcasterWithCheck{c.(*core.Core), currentHeight, stopped}
+	}
+}
+
+type broadcasterWithCheck struct {
+	*core.Core
+	currentHeight uint64
+	stopped       bool
+}
+
+func (s *broadcasterWithCheck) Broadcast(msg message.Msg) {
+	logger := s.Logger().New("step", s.Step())
+	logger.Debug("Broadcasting", "message", msg.String())
+
+	if s.stopped && msg.H() <= s.currentHeight {
+		panic("stopped node sent old consensus message once he came back up")
+	}
+
+	s.BroadcastAll(msg)
+}
+
+// Tests that a stopped node, once restarted, will sync up to chain head before sending consensus messages
+func TestWaitForChainSyncAfterStop(t *testing.T) {
+	network, err := NewNetwork(t, 5, "10e18,v,1,0.0.0.0:%s,%s,%s,%s")
+	require.NoError(t, err)
+	defer network.Shutdown()
+
+	network.WaitToMineNBlocks(10, 60, false)
+
+	// Stop node 0, he will need to sync up once restarted
+	err = network[0].Close(false)
+	require.NoError(t, err)
+	network[0].Wait()
+
+	network.WaitToMineNBlocks(10, 60, false)
+
+	// Stop node 1. This will make the network lose liveness and halt
+	err = network[1].Close(false)
+	require.NoError(t, err)
+	network[1].Wait()
+
+	// network should be stalled now
+	err = network.WaitToMineNBlocks(1, 5, false)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expecting %q, instead got: %v ", context.DeadlineExceeded.Error(), err)
+	}
+
+	// restart node 1. He will rightfully send a consensus message for the consensus instance he stopped at (chainHeight+1)
+	chainHeight := network[2].GetChainHeight()
+	network[1].CustHandler = &interfaces.Services{Broadcaster: NewBroadcasterWithCheck(chainHeight, true)}
+	err = network[1].Start()
+	require.NoError(t, err)
+
+	// give time for node 1 to come back up
+	network.WaitToMineNBlocks(15, 60, false)
+
+	// restart node 0. He should sync up and not send old consensus messages
+	chainHeight = network[2].GetChainHeight()
+	network[0].CustHandler = &interfaces.Services{Broadcaster: NewBroadcasterWithCheck(chainHeight, true)}
+	err = network[0].Start()
+	require.NoError(t, err)
+
+	// give time for node 0 to come back up
+	network.WaitToMineNBlocks(15, 60, false)
+
 }
 
 // Test details
@@ -310,7 +382,7 @@ func TestTendermintQuorum2(t *testing.T) {
 	for i, n := range network {
 		// stop last 3 nodes
 		if i > 2 {
-			err = n.Close()
+			err = n.Close(true)
 			n.Wait()
 			require.NoError(t, err)
 		}
@@ -354,7 +426,7 @@ func TestTendermintQuorum4(t *testing.T) {
 	i := 0
 	for i < 2 {
 		// stop 1st and 2nd node
-		err = network[i].Close()
+		err = network[i].Close(true)
 		require.NoError(t, err)
 		network[i].Wait()
 		i++
@@ -365,7 +437,7 @@ func TestTendermintQuorum4(t *testing.T) {
 	// shutting down 3rd and 4th node
 	for i < 4 {
 		// stop 1st and 2nd node
-		err = network[i].Close()
+		err = network[i].Close(true)
 		require.NoError(t, err)
 		network[i].Wait()
 		i++
@@ -409,7 +481,7 @@ func TestTendermintQuorum4(t *testing.T) {
 	// bring down 5th and 6th node
 	for i < 6 {
 		// stop 1st and 2nd node
-		err = network[i].Close()
+		err = network[i].Close(true)
 		require.NoError(t, err)
 		network[i].Wait()
 		i++
@@ -479,7 +551,7 @@ func TestStartStopAllNodesInParallel(t *testing.T) {
 				if !nodeStatus.status {
 					return
 				}
-				e := network[i].Close()
+				e := network[i].Close(true)
 				require.NoError(t, e)
 				network[i].Wait()
 				nodeStatus.status = false

--- a/e2e_test/node.go
+++ b/e2e_test/node.go
@@ -239,7 +239,7 @@ func (n *Node) Start() error {
 // Close shuts down the node and releases all resources and removes the datadir
 // unless an error is returned, in which case there is no guarantee that all
 // resources are released.
-func (n *Node) Close() error {
+func (n *Node) Close(deleteDataDir bool) error {
 	if !n.isRunning {
 		return nil
 	}
@@ -257,7 +257,9 @@ func (n *Node) Close() error {
 	if n.Node != nil {
 		err = n.Node.Close() // This also shuts down the Eth service
 	}
-	os.RemoveAll(n.Config.DataDir)
+	if deleteDataDir {
+		os.RemoveAll(n.Config.DataDir)
+	}
 	return err
 }
 
@@ -586,7 +588,7 @@ func (nw Network) AwaitTransactions(ctx context.Context, txs ...*types.Transacti
 func (nw Network) Shutdown() {
 	for _, node := range nw {
 		if node != nil && node.isRunning {
-			err := node.Close()
+			err := node.Close(true)
 			if err != nil {
 				fmt.Printf("error shutting down node %v: %v", node.Address.String(), err)
 			}

--- a/eth/api.go
+++ b/eth/api.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/autonity/autonity/log"
 	"io"
 	"math/big"
 	"os"
@@ -29,6 +28,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/autonity/autonity/log"
 
 	"github.com/autonity/autonity/autonity"
 	"github.com/autonity/autonity/common"
@@ -101,6 +102,7 @@ func NewPrivateMinerAPI(e *Ethereum) *PrivateMinerAPI {
 // usable by this process. If mining is already running, this method adjust the
 // number of threads allowed to use and updates the minimum price required by the
 // transaction pool.
+// NOTE: will start mining even if the node is out of sync with the chain head
 func (api *PrivateMinerAPI) Start(threads *int) error {
 	if threads == nil {
 		return api.e.StartMining(runtime.NumCPU())

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -464,6 +464,8 @@ func (s *Ethereum) shouldPreserve(header *types.Header) bool {
 // StartMining starts the miner with the given number of CPU threads. If mining
 // is already running, this method adjust the number of threads allowed to use
 // and updates the minimum price required by the transaction pool.
+// NOTE: this method bypasses the out-of-sync mining prevention check.
+// The node will start mining even if not sure on whether he is synced with the chain head
 func (s *Ethereum) StartMining(threads int) error {
 	// Update the thread count within the consensus engine
 	type threaded interface {
@@ -494,7 +496,7 @@ func (s *Ethereum) StartMining(threads int) error {
 		// introduced to speed sync times.
 		atomic.StoreUint32(&s.handler.acceptTxs, 1)
 
-		go s.miner.Start()
+		go s.miner.ForceStart()
 	}
 	return nil
 }

--- a/eth/downloader/events.go
+++ b/eth/downloader/events.go
@@ -23,3 +23,5 @@ type DoneEvent struct {
 }
 type StartEvent struct{}
 type FailedEvent struct{ Err error }
+
+type SyncedEvent struct{}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -521,7 +521,7 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
 		return
 	}
-	// Otherwise if the block is indeed in out own chain, announce it
+	// Otherwise if the block is indeed in our own chain, announce it
 	if h.chain.HasBlock(hash, block.NumberU64()) {
 		for _, peer := range peers {
 			peer.AsyncSendNewBlockHash(block)

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -18,10 +18,10 @@ package eth
 
 import (
 	"errors"
-	ethereum "github.com/autonity/autonity"
 	"math/big"
 	"sync"
 
+	ethereum "github.com/autonity/autonity"
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/eth/protocols/eth"
 	"github.com/autonity/autonity/eth/protocols/snap"

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -62,11 +62,12 @@ func (h *handler) syncTransactions(p *eth.Peer) {
 
 // chainSyncer coordinates blockchain sync components.
 type chainSyncer struct {
-	handler     *handler
-	force       *time.Timer
-	forced      bool // true when force timer fired
-	peerEventCh chan struct{}
-	doneCh      chan error // non-nil when sync is running
+	handler         *handler
+	force           *time.Timer
+	forced          bool // true when force timer fired
+	peerEventCh     chan struct{}
+	doneCh          chan error // non-nil when sync is running
+	syncedEventSent bool       // true when the downloader.SyncedEvent has been sent (we are synced with our current peerset)
 }
 
 // chainSyncOp is a scheduled sync operation.
@@ -80,8 +81,9 @@ type chainSyncOp struct {
 // newChainSyncer creates a chainSyncer.
 func newChainSyncer(handler *handler) *chainSyncer {
 	return &chainSyncer{
-		handler:     handler,
-		peerEventCh: make(chan struct{}),
+		handler:         handler,
+		peerEventCh:     make(chan struct{}),
+		syncedEventSent: false,
 	}
 }
 
@@ -145,6 +147,7 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	if cs.doneCh != nil {
 		return nil // Sync already running.
 	}
+
 	// Ensure we're at minimum peer count.
 	minPeers := defaultMinSyncPeers
 	if cs.forced {
@@ -158,15 +161,27 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	// We have enough peers, check TD
 	peer := cs.handler.peers.peerWithHighestTD()
 	if peer == nil {
+		// we should never end up here
 		return nil
 	}
 	mode, ourTD := cs.modeAndLocalHead()
 
 	op := peerToSyncOp(mode, peer)
 	if op.td.Cmp(ourTD) <= 0 {
-		return nil // We're in sync.
+		// we are synced with our current peerset
+		// notify miner about it if not yet done (so consensus can be started if needed)
+		cs.postSyncedEvent()
+		return nil
 	}
 	return op
+}
+
+func (cs *chainSyncer) postSyncedEvent() {
+	if cs.syncedEventSent {
+		return
+	}
+	cs.handler.eventMux.Post(downloader.SyncedEvent{})
+	cs.syncedEventSent = true
 }
 
 func peerToSyncOp(mode downloader.SyncMode, p *eth.Peer) *chainSyncOp {

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -161,7 +161,6 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	// We have enough peers, check TD
 	peer := cs.handler.peers.peerWithHighestTD()
 	if peer == nil {
-		// we should never end up here
 		return nil
 	}
 	mode, ourTD := cs.modeAndLocalHead()


### PR DESCRIPTION
This PR aims at providing a quick mitigation for one slashing issue that we saw on Piccadilly. More specifically the issue happens when we start the consensus engine before syncing to the current chain head. This can cause equivocation to be done by the node, because he is going to vote for an old height in which he might have already voted.

Please note that this is not a final fix, it just aims at preventing the most trivial edge case. The question of figuring out whether we are synced or not is not trivial at all, and requires more work to be implemented properly.

Moreover this solution will not be effective if the validator is under attack by malicious node who wants to impede its syncing. This specific problem requires modification on the sync mechanism, exploiting the existance of a segregated consensus network (https://github.com/autonity/autonity/pull/923)

The consensus engine now will start only if:
- we are already in sync with the network
- we completed a chain sync with a peer
- we forced mining start via:
  - devmode
  - call to miner api
  - using the `--mine` flag