### PR TITLE
handle errKnownBlock properly on proposal verification

### DIFF
--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -304,6 +304,13 @@ func (sb *Backend) VerifyProposal(proposal *types.Block) (time.Duration, error) 
 	} else if errors.Is(err, consensus.ErrFutureTimestampBlock) {
 		return time.Unix(int64(proposal.Header().Time), 0).Sub(now()), consensus.ErrFutureTimestampBlock
 	}
+
+	// Here we are considering this proposal invalid because we pruned the parent's state
+	// however this is our local node fault, not the remote proposer fault.
+	if errors.Is(err, consensus.ErrPrunedAncestor) {
+		sb.logger.Error("Rejecting a proposal because local node has pruned parent's state")
+		sb.logger.Error("Please check your pruning settings")
+	}
 	return 0, err
 }
 

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -213,7 +213,7 @@ func (sb *Backend) VerifyProposal(proposal *types.Block) (time.Duration, error) 
 	// NOTE: this function execution is not atomic, the block could be not included at the time of this check
 	// and become included right after we passed the check.
 	if sb.blockchain.HasHeader(proposal.Hash(), proposal.NumberU64()) {
-		return constants.ErrAlreadyHaveBlock
+		return 0, constants.ErrAlreadyHaveBlock
 	}
 
 	// verify the header of proposed proposal

--- a/consensus/tendermint/core/constants/error.go
+++ b/consensus/tendermint/core/constants/error.go
@@ -8,6 +8,8 @@ var (
 	ErrNotFromProposer = errors.New("message does not come from proposer")
 	// ErrAlreadyHaveProposal is returned when we receive a proposal but we previously already processed one.
 	ErrAlreadyHaveProposal = errors.New("a proposal was already processed in the round")
+	// ErrAlreadyHaveBlock is returned when we are processing a proposal but we already included the proposed block in our local chain.
+	ErrAlreadyHaveBlock = errors.New("proposed block is already in our local chain")
 	// ErrHeightClosed is returned when we receive a message for current height, but we already committed a proposal for it.
 	ErrHeightClosed = errors.New("consensus instance already concluded")
 	// ErrFutureHeightMessage is returned when curRoundMessages view is earlier than the

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/autonity/autonity/autonity"
+	"github.com/autonity/autonity/consensus"
 	"github.com/autonity/autonity/consensus/tendermint/core/committee"
 	"github.com/autonity/autonity/consensus/tendermint/core/constants"
 	"github.com/autonity/autonity/consensus/tendermint/core/message"
@@ -88,6 +89,8 @@ func shouldDisconnectSender(err error) bool {
 	case errors.Is(err, constants.ErrHeightClosed):
 		fallthrough
 	case errors.Is(err, constants.ErrAlreadyHaveBlock):
+		fallthrough
+	case errors.Is(err, consensus.ErrPrunedAncestor):
 		fallthrough
 	case errors.Is(err, constants.ErrAlreadyHaveProposal):
 		return false

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -87,6 +87,8 @@ func shouldDisconnectSender(err error) bool {
 		fallthrough
 	case errors.Is(err, constants.ErrHeightClosed):
 		fallthrough
+	case errors.Is(err, constants.ErrAlreadyHaveBlock):
+		fallthrough
 	case errors.Is(err, constants.ErrAlreadyHaveProposal):
 		return false
 	case errors.Is(err, ErrValidatorJailed):

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -204,6 +204,9 @@ func (p *Propose) DecodeRLP(s *rlp.Stream) error {
 	if ext.Height == 0 {
 		return constants.ErrInvalidMessage
 	}
+	if ext.Height != ext.ProposalBlock.NumberU64() {
+		return constants.ErrInvalidMessage
+	}
 	if ext.IsValidRoundNil {
 		if ext.ValidRound != 0 {
 			return constants.ErrInvalidMessage

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -162,7 +162,7 @@ func TestMessageEncodeDecode(t *testing.T) {
 		Address:     address,
 		VotingPower: big.NewInt(2),
 	}
-	lastHeader := &types.Header{Number: new(big.Int).SetUint64(25), Committee: []types.CommitteeMember{*validator}}
+	lastHeader := &types.Header{Number: new(big.Int).SetUint64(2), Committee: []types.CommitteeMember{*validator}}
 	messages := []Msg{
 		NewPropose(1, 2, -1, types.NewBlockWithHeader(lastHeader), signer).MustVerify(stubVerifier),
 		NewPrevote(1, 2, lastHeader.Hash(), signer).MustVerify(stubVerifier),

--- a/consensus/tendermint/core/propose.go
+++ b/consensus/tendermint/core/propose.go
@@ -110,8 +110,12 @@ func (c *Proposer) HandleProposal(ctx context.Context, proposal *message.Propose
 				})
 			})
 			return err
-		} else if errors.Is(err, core.ErrKnownBlock) {
-			return constants.ErrAlreadyHaveProposal
+		}
+		// if the proposal block is already in the chain, no need to prevote for nil
+		if errors.Is(err, core.ErrKnownBlock) || errors.Is(err, constants.ErrAlreadyHaveBlock) {
+			c.logger.Info("Verified proposal that was already in our local chain", "err", err, "duration", duration)
+			c.SetStep(ctx, PrecommitDone) // we do not need to process any more consensus messages for this height
+			return constants.ErrAlreadyHaveBlock
 		}
 		// Proposal is invalid here, we need to prevote nil.
 		// However, we may have already sent a prevote nil in the past without having processed the proposal

--- a/consensus/tendermint/core/propose.go
+++ b/consensus/tendermint/core/propose.go
@@ -9,6 +9,7 @@ import (
 	"github.com/autonity/autonity/consensus"
 	"github.com/autonity/autonity/consensus/tendermint/core/constants"
 	"github.com/autonity/autonity/consensus/tendermint/core/message"
+	"github.com/autonity/autonity/core"
 	"github.com/autonity/autonity/core/types"
 	"github.com/autonity/autonity/metrics"
 )
@@ -109,6 +110,8 @@ func (c *Proposer) HandleProposal(ctx context.Context, proposal *message.Propose
 				})
 			})
 			return err
+		} else if errors.Is(err, core.ErrKnownBlock) {
+			return constants.ErrAlreadyHaveProposal
 		}
 		// Proposal is invalid here, we need to prevote nil.
 		// However, we may have already sent a prevote nil in the past without having processed the proposal

--- a/consensus/tendermint/core/rules.go
+++ b/consensus/tendermint/core/rules.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/autonity/autonity/common"
@@ -136,7 +135,7 @@ func (c *Core) quorumPrecommitsCheck(ctx context.Context, proposal *message.Prop
 				return true
 			}
 			// Impossible with the BFT assumptions of 1/3rd honest.
-			panic(fmt.Sprintf("Fatal Safety Error: Quorum on unverifiable proposal. err: %s", err.Error()))
+			panic("Fatal Safety Error: Quorum on unverifiable proposal. err: " + err.Error())
 		}
 	}
 

--- a/consensus/tendermint/core/rules.go
+++ b/consensus/tendermint/core/rules.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/autonity/autonity/common"
@@ -135,8 +136,7 @@ func (c *Core) quorumPrecommitsCheck(ctx context.Context, proposal *message.Prop
 				return true
 			}
 			// Impossible with the BFT assumptions of 1/3rd honest.
-			c.logger.Error("Failed verification of committed proposal", "err", err)
-			panic("Fatal Safety Error: Quorum on unverifiable proposal")
+			panic(fmt.Sprintf("Fatal Safety Error: Quorum on unverifiable proposal. err: %s", err.Error()))
 		}
 	}
 

--- a/consensus/tendermint/core/rules.go
+++ b/consensus/tendermint/core/rules.go
@@ -135,7 +135,7 @@ func (c *Core) quorumPrecommitsCheck(ctx context.Context, proposal *message.Prop
 				return true
 			}
 			// Impossible with the BFT assumptions of 1/3rd honest.
-			sb.logger.Error("Failed verification of committed proposal", "err", err)
+			c.logger.Error("Failed verification of committed proposal", "err", err)
 			panic("Fatal Safety Error: Quorum on unverifiable proposal")
 		}
 	}

--- a/consensus/tendermint/core/rules.go
+++ b/consensus/tendermint/core/rules.go
@@ -2,10 +2,12 @@ package core
 
 import (
 	"context"
+	"errors"
 	"math/big"
 
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/consensus/tendermint/core/message"
+	"github.com/autonity/autonity/core"
 )
 
 // Line 22 in Algorithm 1 of The latest gossip on BFT consensus
@@ -123,6 +125,9 @@ func (c *Core) quorumPrecommitsCheck(ctx context.Context, proposal *message.Prop
 	// if there is a quorum, verify the proposal if needed
 	if !verified {
 		if _, err := c.backend.VerifyProposal(proposal.Block()); err != nil {
+			if errors.Is(err, core.ErrKnownBlock) {
+				return true
+			}
 			// Impossible with the BFT assumptions of 1/3rd honest.
 			panic("Fatal Safety Error: Quorum on unverifiable proposal")
 		}

--- a/consensus/tendermint/core/rules.go
+++ b/consensus/tendermint/core/rules.go
@@ -135,6 +135,7 @@ func (c *Core) quorumPrecommitsCheck(ctx context.Context, proposal *message.Prop
 				return true
 			}
 			// Impossible with the BFT assumptions of 1/3rd honest.
+			sb.logger.Error("Failed verification of committed proposal", "err", err)
 			panic("Fatal Safety Error: Quorum on unverifiable proposal")
 		}
 	}

--- a/consensus/tendermint/core/rules.go
+++ b/consensus/tendermint/core/rules.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/autonity/autonity/common"
+	"github.com/autonity/autonity/consensus/tendermint/core/constants"
 	"github.com/autonity/autonity/consensus/tendermint/core/message"
 	"github.com/autonity/autonity/core"
 )
@@ -125,7 +126,12 @@ func (c *Core) quorumPrecommitsCheck(ctx context.Context, proposal *message.Prop
 	// if there is a quorum, verify the proposal if needed
 	if !verified {
 		if _, err := c.backend.VerifyProposal(proposal.Block()); err != nil {
-			if errors.Is(err, core.ErrKnownBlock) {
+			// This can happen if while we are processing the proposal,
+			// we actually receive the finalized proposed block from p2p block propagation (other peers already reached quorum on it)
+			// In this case we can just consider the proposal as committed.
+			if errors.Is(err, core.ErrKnownBlock) || errors.Is(err, constants.ErrAlreadyHaveBlock) {
+				c.logger.Info("Verified proposal that was already in our local chain", "err", err)
+				c.SetStep(ctx, PrecommitDone) // we do not need to process any more consensus messages for this height
 				return true
 			}
 			// Impossible with the BFT assumptions of 1/3rd honest.


### PR DESCRIPTION
handle ErrknownBlock from proposal verification properly. Additionally, We check if the height in proposal Message is same as the proposedBlock number to avoid processing the old valid proposal again.