### PR TITLE
[ReadyForReview] Repair APE framework for ASM tests.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -330,9 +330,6 @@ jobs:
             ${{ env.GO_MODULES_CACHE }}
           key: ${{ runner.os }}-gocache-${{ env.GO_VERSION }}${{ hashFiles('go.mod', 'go.sum') }}
 
-      - name: Install Solidity Compiler
-        run: npm install -g solc@0.8.24
-
       - name: Install dependencies
         run: make test-contracts-asm-pre
       - name: run test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -330,6 +330,9 @@ jobs:
             ${{ env.GO_MODULES_CACHE }}
           key: ${{ runner.os }}-gocache-${{ env.GO_VERSION }}${{ hashFiles('go.mod', 'go.sum') }}
 
+      - name: Install Solidity Compiler
+        run: npm install -g solc@0.8.24
+
       - name: Install dependencies
         run: make test-contracts-asm-pre
       - name: run test

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ test-contracts-asm-pre:
 	@cd $(CONTRACTS_BASE_DIR) && npm list hardhat@$(HARDHAT_VERSION) > /dev/null || npm install hardhat@$(HARDHAT_VERSION)
 	@echo "install ape framework plugins"
 	@cd $(CONTRACTS_BASE_DIR) && ape plugins install -y --verbosity ERROR .
+	@echo "dependencies installed"
 
 # start an autonity network for contract tests
 start-autonity:

--- a/autonity/solidity/ape-config.yaml
+++ b/autonity/solidity/ape-config.yaml
@@ -4,7 +4,8 @@ contracts_folder: contracts
 
 plugins:
   - name: hardhat==0.6.13
-  - name: solidity==0.6.11
+  #- name: solidity==0.6.11
+  - name: solidity==0.7.1
 
 # Ignore `bindings.sol` to speed up compilation. This is because compiling it
 # doesn't result in a cached JSON file under `.build/`, and so it must be

--- a/autonity/solidity/ape-config.yaml
+++ b/autonity/solidity/ape-config.yaml
@@ -4,8 +4,7 @@ contracts_folder: contracts
 
 plugins:
   - name: hardhat==0.6.13
-  #- name: solidity==0.6.11
-  - name: solidity==0.7.1
+  - name: solidity==0.6.11
 
 # Ignore `bindings.sol` to speed up compilation. This is because compiling it
 # doesn't result in a cached JSON file under `.build/`, and so it must be

--- a/autonity/solidity/ape-config.yaml
+++ b/autonity/solidity/ape-config.yaml
@@ -2,6 +2,9 @@
 
 contracts_folder: contracts
 
+solidity:
+  version: 0.8.24
+
 plugins:
   - name: hardhat==0.6.13
   - name: solidity==0.6.11


### PR DESCRIPTION
This PR present the repairing of APE framework for ASM tests. As current HardHat is not compatible with the latest version of solc, 0.8.25, thus we have to specify the solidity version in the ape-config file.