### PR TITLE
prioritize candidate receiver, move subscription to channel

### DIFF
--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -199,7 +199,14 @@ func (sb *Backend) Commit(proposal *types.Block, round int64, seals [][]byte) er
 }
 
 func (sb *Backend) Post(ev any) {
-	sb.eventMux.Post(ev)
+	switch ev.(type) {
+	case events.CommitEvent:
+		sb.core.Post(ev)
+	case events.NewCandidateBlockEvent:
+		sb.core.Post(ev)
+	default:
+		sb.eventMux.Post(ev)
+	}
 }
 
 func (sb *Backend) Subscribe(types ...any) *event.TypeMuxSubscription {

--- a/consensus/tendermint/core/core.go
+++ b/consensus/tendermint/core/core.go
@@ -11,6 +11,7 @@ import (
 	"github.com/autonity/autonity/consensus/tendermint/core/constants"
 	"github.com/autonity/autonity/consensus/tendermint/core/interfaces"
 	"github.com/autonity/autonity/consensus/tendermint/core/message"
+	"github.com/autonity/autonity/consensus/tendermint/events"
 	"github.com/autonity/autonity/core/types"
 	"github.com/autonity/autonity/event"
 	"github.com/autonity/autonity/log"
@@ -69,8 +70,8 @@ type Core struct {
 	cancel  context.CancelFunc
 
 	messageSub          *event.TypeMuxSubscription
-	candidateBlockSub   *event.TypeMuxSubscription
-	committedSub        *event.TypeMuxSubscription
+	candidateBlockCh    chan events.NewCandidateBlockEvent
+	committedCh         chan events.CommitEvent
 	timeoutEventSub     *event.TypeMuxSubscription
 	syncEventSub        *event.TypeMuxSubscription
 	futureProposalTimer *time.Timer
@@ -145,6 +146,15 @@ func (c *Core) Address() common.Address {
 
 func (c *Core) Step() Step {
 	return c.step
+}
+
+func (c *Core) Post(ev any) {
+	switch ev := ev.(type) {
+	case events.CommitEvent:
+		c.committedCh <- ev
+	case events.NewCandidateBlockEvent:
+		c.candidateBlockCh <- ev
+	}
 }
 
 func (c *Core) CurRoundMessages() *message.RoundMessages {
@@ -519,7 +529,6 @@ type Broadcaster struct {
 }
 
 func (s *Broadcaster) Broadcast(msg message.Msg) {
-	logger := s.Logger().New("step", s.Step())
-	logger.Debug("Broadcasting", "message", msg.String())
+	s.logger.Debug("Broadcasting", "message", log.Lazy{Fn: msg.String})
 	s.BroadcastAll(msg)
 }

--- a/consensus/tendermint/core/interfaces/core_backend.go
+++ b/consensus/tendermint/core/interfaces/core_backend.go
@@ -88,4 +88,5 @@ type Core interface {
 	Proposer() Proposer
 	Prevoter() Prevoter
 	Precommiter() Precommiter
+	Post(ev any)
 }


### PR DESCRIPTION
We priortize candidate channel read in core handler loop to avoid any delays introduced due to other messages. We have also moved it out of the event multiplexer to make it simple