### PR TITLE
Remove core mutex

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -129,6 +129,9 @@ type Engine interface {
 
 	// Close terminates any background threads maintained by the consensus engine.
 	Close() error
+
+	// SetResultChan sets the result channel to handle sealing result
+	SetResultChan(results chan<- *types.Block)
 }
 
 // Handler should be implemented is the consensus needs to handle and send peer's message

--- a/consensus/consensus_mock.go
+++ b/consensus/consensus_mock.go
@@ -433,6 +433,18 @@ func (mr *MockEngineMockRecorder) SealHash(header any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SealHash", reflect.TypeOf((*MockEngine)(nil).SealHash), header)
 }
 
+// SetResultChan mocks base method.
+func (m *MockEngine) SetResultChan(results chan<- *types.Block) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetResultChan", results)
+}
+
+// SetResultChan indicates an expected call of SetResultChan.
+func (mr *MockEngineMockRecorder) SetResultChan(results any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetResultChan", reflect.TypeOf((*MockEngine)(nil).SetResultChan), results)
+}
+
 // VerifyHeader mocks base method.
 func (m *MockEngine) VerifyHeader(chain ChainHeaderReader, header *types.Header, seal bool) error {
 	m.ctrl.T.Helper()
@@ -734,6 +746,18 @@ func (mr *MockPoWMockRecorder) SealHash(header any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SealHash", reflect.TypeOf((*MockPoW)(nil).SealHash), header)
 }
 
+// SetResultChan mocks base method.
+func (m *MockPoW) SetResultChan(results chan<- *types.Block) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetResultChan", results)
+}
+
+// SetResultChan indicates an expected call of SetResultChan.
+func (mr *MockPoWMockRecorder) SetResultChan(results any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetResultChan", reflect.TypeOf((*MockPoW)(nil).SetResultChan), results)
+}
+
 // VerifyHeader mocks base method.
 func (m *MockPoW) VerifyHeader(chain ChainHeaderReader, header *types.Header, seal bool) error {
 	m.ctrl.T.Helper()
@@ -928,6 +952,18 @@ func (m *MockBFT) SealHash(header *types.Header) common.Hash {
 func (mr *MockBFTMockRecorder) SealHash(header any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SealHash", reflect.TypeOf((*MockBFT)(nil).SealHash), header)
+}
+
+// SetResultChan mocks base method.
+func (m *MockBFT) SetResultChan(results chan<- *types.Block) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetResultChan", results)
+}
+
+// SetResultChan indicates an expected call of SetResultChan.
+func (mr *MockBFTMockRecorder) SetResultChan(results any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetResultChan", reflect.TypeOf((*MockBFT)(nil).SetResultChan), results)
 }
 
 // Start mocks base method.

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -22,10 +22,6 @@ import (
 	crand "crypto/rand"
 	"encoding/json"
 	"errors"
-	"github.com/autonity/autonity/common"
-	"github.com/autonity/autonity/common/hexutil"
-	"github.com/autonity/autonity/consensus"
-	"github.com/autonity/autonity/core/types"
 	"math"
 	"math/big"
 	"math/rand"
@@ -33,6 +29,11 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/autonity/autonity/common"
+	"github.com/autonity/autonity/common/hexutil"
+	"github.com/autonity/autonity/consensus"
+	"github.com/autonity/autonity/core/types"
 )
 
 const (
@@ -44,6 +45,8 @@ var (
 	errNoMiningWork      = errors.New("no mining work available yet")
 	errInvalidSealResult = errors.New("invalid or stale proof-of-work solution")
 )
+
+func (ethash *Ethash) SetResultChan(_ chan<- *types.Block) {}
 
 // Seal implements consensus.Engine, attempting to find a nonce that satisfies
 // the block's difficulty requirements.
@@ -338,10 +341,11 @@ func (s *remoteSealer) loop() {
 // makeWork creates a work package for external miner.
 //
 // The work package consists of 3 strings:
-//   result[0], 32 bytes hex encoded current block header pow-hash
-//   result[1], 32 bytes hex encoded seed hash used for DAG
-//   result[2], 32 bytes hex encoded boundary condition ("target"), 2^256/difficulty
-//   result[3], hex encoded block number
+//
+//	result[0], 32 bytes hex encoded current block header pow-hash
+//	result[1], 32 bytes hex encoded seed hash used for DAG
+//	result[2], 32 bytes hex encoded boundary condition ("target"), 2^256/difficulty
+//	result[3], hex encoded block number
 func (s *remoteSealer) makeWork(block *types.Block) {
 	hash := s.ethash.SealHash(block.Header())
 	s.currentWork[0] = hash.Hex()

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/autonity/autonity/consensus/tendermint/core/constants"
@@ -57,7 +58,6 @@ func New(privateKey *ecdsa.PrivateKey,
 		privateKey:     privateKey,
 		address:        crypto.PubkeyToAddress(privateKey.PublicKey),
 		logger:         log,
-		coreStarted:    false,
 		recentMessages: recentMessages,
 		knownMessages:  knownMessages,
 		vmConfig:       vmConfig,
@@ -90,7 +90,8 @@ type Backend struct {
 	// the channels for tendermint engine notifications
 	commitCh          chan<- *types.Block
 	proposedBlockHash common.Hash
-	coreStarted       bool
+	coreStarting      atomic.Bool
+	coreRunning       atomic.Bool
 	core              interfaces.Core
 	stopped           chan struct{}
 	wg                sync.WaitGroup

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -95,7 +95,6 @@ type Backend struct {
 	core              interfaces.Core
 	stopped           chan struct{}
 	wg                sync.WaitGroup
-	coreMu            sync.RWMutex
 
 	// we save the last received p2p.messages in the ring buffer
 	pendingMessages ring.Ring

--- a/consensus/tendermint/backend/backend_test.go
+++ b/consensus/tendermint/backend/backend_test.go
@@ -275,7 +275,7 @@ func TestCommit(t *testing.T) {
 		_, backend := newBlockChain(4)
 
 		commitCh := make(chan *types.Block, 1)
-		backend.setResultChan(commitCh)
+		backend.SetResultChan(commitCh)
 
 		// Case: it's a proposer, so the Backend.commit will receive channel result from Backend.Commit function
 		testCases := []struct {

--- a/consensus/tendermint/backend/backend_test.go
+++ b/consensus/tendermint/backend/backend_test.go
@@ -581,6 +581,7 @@ func makeBlock(chain *core.BlockChain, engine *Backend, parent *types.Block) (*t
 	}
 
 	resultCh := make(chan *types.Block)
+	engine.SetResultChan(resultCh)
 	err = engine.Seal(chain, block, resultCh, nil)
 	if err != nil {
 		return nil, err

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -7,20 +7,19 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/autonity/autonity/consensus/tendermint"
-	"github.com/autonity/autonity/consensus/tendermint/core/message"
-	"github.com/autonity/autonity/crypto"
-
 	"github.com/autonity/autonity/autonity"
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/consensus"
 	"github.com/autonity/autonity/consensus/misc"
+	"github.com/autonity/autonity/consensus/tendermint"
 	"github.com/autonity/autonity/consensus/tendermint/bft"
 	"github.com/autonity/autonity/consensus/tendermint/core/constants"
+	"github.com/autonity/autonity/consensus/tendermint/core/message"
 	"github.com/autonity/autonity/consensus/tendermint/events"
 	"github.com/autonity/autonity/core"
 	"github.com/autonity/autonity/core/state"
 	"github.com/autonity/autonity/core/types"
+	"github.com/autonity/autonity/crypto"
 	"github.com/autonity/autonity/event"
 	"github.com/autonity/autonity/params"
 	"github.com/autonity/autonity/rpc"
@@ -347,12 +346,8 @@ func (sb *Backend) AutonityContractFinalize(header *types.Header, chain consensu
 
 // Seal generates a new block for the given input block with the local miner's
 // seal place on top.
-func (sb *Backend) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
-	sb.coreMu.RLock()
-	isStarted := sb.coreStarted
-	stoppedCh := sb.stopped
-	sb.coreMu.RUnlock()
-	if !isStarted {
+func (sb *Backend) Seal(chain consensus.ChainReader, block *types.Block, _ chan<- *types.Block, stop <-chan struct{}) error {
+	if !sb.coreRunning.Load() {
 		return ErrStoppedEngine
 	}
 	// update the block header and signature and propose the block to core engine
@@ -379,37 +374,29 @@ func (sb *Backend) Seal(chain consensus.ChainReader, block *types.Block, results
 	select {
 	case <-time.After(delay):
 		// nothing to do
-	case <-stoppedCh:
+	case <-sb.stopped:
 		return nil
 	case <-stop:
 		return nil
 	}
-	sb.setResultChan(results)
+
 	// post block into BFT engine
 	sb.Post(events.NewCandidateBlockEvent{
 		NewCandidateBlock: *block,
 	})
+
 	return nil
 }
 
-func (sb *Backend) setResultChan(results chan<- *types.Block) {
-	sb.coreMu.Lock()
-	defer sb.coreMu.Unlock()
-
+func (sb *Backend) SetResultChan(results chan<- *types.Block) {
 	sb.commitCh = results
 }
 
 func (sb *Backend) sendResultChan(block *types.Block) {
-	sb.coreMu.Lock()
-	defer sb.coreMu.Unlock()
-
 	sb.commitCh <- block
 }
 
 func (sb *Backend) isResultChanNil() bool {
-	sb.coreMu.RLock()
-	defer sb.coreMu.RUnlock()
-
 	return sb.commitCh == nil
 }
 
@@ -461,11 +448,12 @@ func getCommittee(header *types.Header, chain consensus.ChainReader) (types.Comm
 // youssef: I'm not sure about the use case of this context in argument
 func (sb *Backend) Start(ctx context.Context) error {
 	// the mutex along with coreStarted should prevent double start
-	sb.coreMu.Lock()
-	defer sb.coreMu.Unlock()
-	if sb.coreStarted {
+	//sb.coreMu.Lock()
+	//defer sb.coreMu.Unlock()
+	if !sb.coreStarting.CompareAndSwap(false, true) {
 		return ErrStartedEngine
 	}
+
 	sb.stopped = make(chan struct{})
 	sb.UpdateStopChannel(sb.stopped)
 	// clear previous data
@@ -474,20 +462,16 @@ func (sb *Backend) Start(ctx context.Context) error {
 	go sb.faultyValidatorsWatcher(ctx)
 	sb.wg.Add(1)
 	sb.core.Start(ctx, sb.blockchain.ProtocolContracts())
-	sb.coreStarted = true
+	sb.coreRunning.CompareAndSwap(false, true)
 	return nil
 }
 
 // Close signals core to stop all background threads.
 func (sb *Backend) Close() error {
-	// the mutex along with coreStarted should prevent double stop
-	sb.coreMu.Lock()
-	if !sb.coreStarted {
-		sb.coreMu.Unlock()
+	if !sb.coreStarting.CompareAndSwap(true, false) {
 		return ErrStoppedEngine
 	}
-	sb.coreStarted = false
-	sb.coreMu.Unlock()
+	sb.coreRunning.CompareAndSwap(true, false)
 	// We need to make sure we close sb.stopped before calling sb.core.Stop
 	// otherwise we can end up with a deadlock where sb.core.Stop is waiting
 	// for a routine to return from calling sb.AskSync but sb.AskSync will

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -447,9 +447,6 @@ func getCommittee(header *types.Header, chain consensus.ChainReader) (types.Comm
 // Start implements consensus.Start
 // youssef: I'm not sure about the use case of this context in argument
 func (sb *Backend) Start(ctx context.Context) error {
-	// the mutex along with coreStarted should prevent double start
-	//sb.coreMu.Lock()
-	//defer sb.coreMu.Unlock()
 	if !sb.coreStarting.CompareAndSwap(false, true) {
 		return ErrStartedEngine
 	}

--- a/consensus/tendermint/backend/engine_test.go
+++ b/consensus/tendermint/backend/engine_test.go
@@ -62,6 +62,7 @@ func TestSealCommittedOtherHash(t *testing.T) {
 	go eventLoop()
 	seal := func() {
 		resultCh := make(chan *types.Block)
+		engine.SetResultChan(resultCh)
 		err = engine.Seal(chain, block, resultCh, nil)
 		if err != nil {
 			t.Error("seal should not return error", err.Error())
@@ -87,6 +88,7 @@ func TestSealCommitted(t *testing.T) {
 	expectedBlock, _ := engine.AddSeal(block)
 
 	resultCh := make(chan *types.Block)
+	engine.SetResultChan(resultCh)
 	err = engine.Seal(chain, block, resultCh, nil)
 	if err != nil {
 		t.Errorf("error mismatch: have %v, want nil", err)
@@ -422,10 +424,11 @@ func TestClose(t *testing.T) {
 		tendermintC.EXPECT().Stop().MaxTimes(1)
 
 		b := &Backend{
-			core:        tendermintC,
-			coreStarted: true,
-			stopped:     make(chan struct{}),
+			core:    tendermintC,
+			stopped: make(chan struct{}),
 		}
+		b.coreStarting.Store(true)
+		b.coreRunning.Store(true)
 
 		err := b.Close()
 		assertNilError(t, err)
@@ -440,10 +443,11 @@ func TestClose(t *testing.T) {
 		tendermintC.EXPECT().Stop().MaxTimes(1)
 
 		b := &Backend{
-			core:        tendermintC,
-			coreStarted: true,
-			stopped:     make(chan struct{}),
+			core:    tendermintC,
+			stopped: make(chan struct{}),
 		}
+		b.coreStarting.Store(true)
+		b.coreRunning.Store(true)
 
 		err := b.Close()
 		assertNilError(t, err)
@@ -462,10 +466,11 @@ func TestClose(t *testing.T) {
 		tendermintC.EXPECT().Stop().MaxTimes(1)
 
 		b := &Backend{
-			core:        tendermintC,
-			coreStarted: true,
-			stopped:     make(chan struct{}),
+			core:    tendermintC,
+			stopped: make(chan struct{}),
 		}
+		b.coreStarting.Store(true)
+		b.coreRunning.Store(true)
 
 		var wg sync.WaitGroup
 		stop := 10
@@ -514,10 +519,9 @@ func TestStart(t *testing.T) {
 		g.EXPECT().UpdateStopChannel(gomock.Any())
 
 		b := &Backend{
-			core:        tendermintC,
-			gossiper:    g,
-			coreStarted: false,
-			blockchain:  chain,
+			core:       tendermintC,
+			gossiper:   g,
+			blockchain: chain,
 		}
 
 		err := b.Start(ctx)
@@ -526,9 +530,9 @@ func TestStart(t *testing.T) {
 	})
 
 	t.Run("engine is running, error returned", func(t *testing.T) {
-		b := &Backend{
-			coreStarted: true,
-		}
+		b := &Backend{}
+		b.coreStarting.Store(true)
+		b.coreRunning.Store(true)
 
 		err := b.Start(context.Background())
 		assertError(t, ErrStartedEngine, err)
@@ -547,11 +551,11 @@ func TestStart(t *testing.T) {
 		g.EXPECT().UpdateStopChannel(gomock.Any())
 
 		b := &Backend{
-			core:        tendermintC,
-			gossiper:    g,
-			coreStarted: false,
-			blockchain:  chain,
+			core:       tendermintC,
+			gossiper:   g,
+			blockchain: chain,
 		}
+		b.coreStarting.Store(false)
 
 		err := b.Start(ctx)
 		assertNilError(t, err)
@@ -573,11 +577,11 @@ func TestStart(t *testing.T) {
 		g.EXPECT().UpdateStopChannel(gomock.Any())
 
 		b := &Backend{
-			core:        tendermintC,
-			gossiper:    g,
-			coreStarted: false,
-			blockchain:  chain,
+			core:       tendermintC,
+			gossiper:   g,
+			blockchain: chain,
 		}
+		b.coreStarting.Store(false)
 
 		var wg sync.WaitGroup
 		stop := 10
@@ -628,11 +632,11 @@ func TestMultipleRestart(t *testing.T) {
 	g.EXPECT().UpdateStopChannel(gomock.Any()).MaxTimes(5)
 
 	b := &Backend{
-		core:        tendermintC,
-		gossiper:    g,
-		coreStarted: false,
-		blockchain:  chain,
+		core:       tendermintC,
+		gossiper:   g,
+		blockchain: chain,
 	}
+	b.coreStarting.Store(false)
 
 	for i := 0; i < times; i++ {
 		err := b.Start(ctx)
@@ -661,14 +665,14 @@ func assertNilError(t *testing.T, err error) {
 
 func assertCoreStarted(t *testing.T, b *Backend) {
 	t.Helper()
-	if !b.coreStarted {
+	if !b.coreRunning.Load() {
 		t.Fatal("expected core to have started")
 	}
 }
 
 func assertNotCoreStarted(t *testing.T, b *Backend) {
 	t.Helper()
-	if b.coreStarted {
+	if b.coreRunning.Load() {
 		t.Fatal("expected core to have stopped")
 	}
 }

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -67,9 +67,6 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, errCh chan<- erro
 		return false, nil
 	}
 
-	sb.coreMu.Lock()
-	defer sb.coreMu.Unlock()
-
 	switch msg.Code {
 	case ProposeNetworkMsg:
 		return handleConsensusMsg[message.Propose](sb, addr, msg, errCh)

--- a/consensus/tendermint/backend/handler_test.go
+++ b/consensus/tendermint/backend/handler_test.go
@@ -60,9 +60,8 @@ func TestSynchronisationMessage(t *testing.T) {
 		eventMux := event.NewTypeMuxSilent(nil, log.New("backend", "test", "id", 0))
 		sub := eventMux.Subscribe(events.SyncEvent{})
 		b := &Backend{
-			coreStarted: false,
-			logger:      log.New("backend", "test", "id", 0),
-			eventMux:    eventMux,
+			logger:   log.New("backend", "test", "id", 0),
+			eventMux: eventMux,
 		}
 		msg := makeMsg(SyncNetworkMsg, []byte{})
 		addr := common.BytesToAddress([]byte("address"))
@@ -82,10 +81,11 @@ func TestSynchronisationMessage(t *testing.T) {
 		eventMux := event.NewTypeMuxSilent(nil, log.New("backend", "test", "id", 0))
 		sub := eventMux.Subscribe(events.SyncEvent{})
 		b := &Backend{
-			coreStarted: true,
-			logger:      log.New("backend", "test", "id", 0),
-			eventMux:    eventMux,
+			logger:   log.New("backend", "test", "id", 0),
+			eventMux: eventMux,
 		}
+		b.coreStarting.Store(true)
+		b.coreRunning.Store(true)
 		msg := makeMsg(SyncNetworkMsg, []byte{})
 		addr := common.BytesToAddress([]byte("address"))
 		errCh := make(chan error, 1)
@@ -124,9 +124,9 @@ func TestNewChainHead(t *testing.T) {
 
 	t.Run("engine is running, no errors", func(t *testing.T) {
 		b := &Backend{
-			coreStarted: true,
-			eventMux:    event.NewTypeMuxSilent(nil, log.New("backend", "test", "id", 0)),
+			eventMux: event.NewTypeMuxSilent(nil, log.New("backend", "test", "id", 0)),
 		}
+		b.coreRunning.Store(true)
 
 		err := b.NewChainHead()
 		if err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -280,6 +280,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 	// Subscribe events for blockchain
 	worker.chainHeadSub = eth.BlockChain().SubscribeChainHeadEvent(worker.chainHeadCh)
 	worker.chainSideSub = eth.BlockChain().SubscribeChainSideEvent(worker.chainSideCh)
+	worker.engine.SetResultChan(worker.resultCh)
 
 	// Sanitize recommit interval if the user-specified one is too short.
 	recommit := worker.config.Recommit
@@ -640,7 +641,6 @@ func (w *worker) taskLoop() {
 			stopCh = nil
 		}
 	}
-	w.engine.SetResultChan(w.resultCh)
 	for {
 		select {
 		case task := <-w.taskCh:

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -28,6 +28,8 @@ import (
 	"github.com/autonity/autonity/consensus/tendermint/backend"
 	"github.com/autonity/autonity/metrics"
 
+	mapset "github.com/deckarep/golang-set"
+
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/consensus"
 	"github.com/autonity/autonity/consensus/misc"
@@ -38,7 +40,6 @@ import (
 	"github.com/autonity/autonity/log"
 	"github.com/autonity/autonity/params"
 	"github.com/autonity/autonity/trie"
-	mapset "github.com/deckarep/golang-set"
 )
 
 const (
@@ -639,6 +640,7 @@ func (w *worker) taskLoop() {
 			stopCh = nil
 		}
 	}
+	w.engine.SetResultChan(w.resultCh)
 	for {
 		select {
 		case task := <-w.taskCh:


### PR DESCRIPTION
We make use of 2 atomic variables to remove core mutex.
CoreStarting: this is to prevent double start/stop.
CoreRunning: this only gets set when core is properly initialized and running.

Also, SetResultCh is now invoked from worker(taskLoop). Thereby eliminating the need of setting resultChannel on every sealing operation.
