### PR TITLE
expirable cache

### DIFF
--- a/consensus/acn/acn.go
+++ b/consensus/acn/acn.go
@@ -103,8 +103,15 @@ func (acn *ACN) runConsensusPeer(peer *protocol.Peer, handler protocol.HandlerFu
 		peer.Log().Error("peer registration failed", "err", err)
 		return err
 	}
-	defer acn.peers.unregister(peer.ID())
+	defer acn.unregisterPeer(peer)
 	return handler(peer)
+}
+
+func (acn *ACN) unregisterPeer(peer *protocol.Peer) {
+	if syncer, ok := acn.chain.Engine().(consensus.Syncer); ok {
+		syncer.ResetPeerCache(peer.Address())
+	}
+	acn.peers.unregister(peer.ID())
 }
 
 func (acn *ACN) Stop() error {

--- a/consensus/tendermint/backend/backend_test.go
+++ b/consensus/tendermint/backend/backend_test.go
@@ -145,9 +145,9 @@ func BenchmarkGossipLRU(b *testing.B) {
 	address3Cache.Add(msgs[0].Hash(), true)
 	recentMessages.Add(addresses[3], address3Cache)
 	bk := &Backend{
-		knownMessages:  knownMessages,
-		recentMessages: recentMessages,
-		gossiper:       NewGossiper(recentMessages, knownMessages, common.Address{}, log.New(), make(chan struct{})),
+		knownMessages:     knownMessages,
+		peerKnownMessages: recentMessages,
+		gossiper:          NewGossiper(recentMessages, knownMessages, common.Address{}, log.New(), make(chan struct{})),
 	}
 	bk.SetBroadcaster(broadcaster)
 
@@ -200,9 +200,9 @@ func TestGossip(t *testing.T) {
 	address3Cache.Add(msg.Hash(), true)
 	recentMessages.Add(addresses[3], address3Cache)
 	b := &Backend{
-		knownMessages:  knownMessages,
-		recentMessages: recentMessages,
-		gossiper:       NewGossiper(recentMessages, knownMessages, common.Address{}, log.New(), make(chan struct{})),
+		knownMessages:     knownMessages,
+		peerKnownMessages: recentMessages,
+		gossiper:          NewGossiper(recentMessages, knownMessages, common.Address{}, log.New(), make(chan struct{})),
 	}
 	b.SetBroadcaster(broadcaster)
 
@@ -269,7 +269,7 @@ func TestResetPeerCache(t *testing.T) {
 	recentMessages.Add(addr, msgCache)
 
 	b := &Backend{
-		recentMessages: recentMessages,
+		peerKnownMessages: recentMessages,
 	}
 
 	b.ResetPeerCache(addr)
@@ -454,10 +454,10 @@ func TestSyncPeer(t *testing.T) {
 		gossiper := interfaces.NewMockGossiper(ctrl)
 		gossiper.EXPECT().SetBroadcaster(broadcaster).Times(1)
 		b := &Backend{
-			logger:         log.New("backend", "test", "id", 0),
-			gossiper:       gossiper,
-			recentMessages: recentMessages,
-			core:           tendermintC,
+			logger:            log.New("backend", "test", "id", 0),
+			gossiper:          gossiper,
+			peerKnownMessages: recentMessages,
+			core:              tendermintC,
 		}
 		b.SetBroadcaster(broadcaster)
 

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	ttlSec = time.Second * 30
+	ttl = time.Second * 20
 )
 
 // ErrStartedEngine is returned if the engine is already started

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -28,9 +28,7 @@ import (
 )
 
 const (
-	inmemorySnapshots = 128 // Number of recent vote snapshots to keep in memory
-	inmemoryPeers     = 150
-	inmemoryMessages  = 8192
+	ttlSec = time.Second * 30
 )
 
 // ErrStartedEngine is returned if the engine is already started

--- a/consensus/tendermint/backend/gossiper.go
+++ b/consensus/tendermint/backend/gossiper.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
 
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/consensus"
@@ -15,21 +15,23 @@ import (
 )
 
 type Gossiper struct {
-	recentMessages *lru.ARCCache  // the cache of peer's messages
-	knownMessages  *lru.ARCCache  // the cache of self messages
-	address        common.Address // address of the local peer
-	broadcaster    consensus.Broadcaster
-	logger         log.Logger
-	stopped        chan struct{}
+	recentMessages     *lru.LRU[common.Address, *lru.LRU[common.Hash, bool]] // the cache of peer's messages
+	knownMessages      *lru.LRU[common.Hash, bool]                           // the cache of self messages
+	address            common.Address                                        // address of the local peer
+	broadcaster        consensus.Broadcaster
+	logger             log.Logger
+	stopped            chan struct{}
+	concurrencyLimiter chan struct{}
 }
 
-func NewGossiper(recentMessages *lru.ARCCache, knownMessages *lru.ARCCache, address common.Address, logger log.Logger, stopped chan struct{}) *Gossiper {
+func NewGossiper(recentMessages *lru.LRU[common.Address, *lru.LRU[common.Hash, bool]], knownMessages *lru.LRU[common.Hash, bool], address common.Address, logger log.Logger, stopped chan struct{}) *Gossiper {
 	return &Gossiper{
-		recentMessages: recentMessages,
-		knownMessages:  knownMessages,
-		address:        address,
-		logger:         logger,
-		stopped:        stopped,
+		recentMessages:     recentMessages,
+		knownMessages:      knownMessages,
+		address:            address,
+		logger:             logger,
+		stopped:            stopped,
+		concurrencyLimiter: make(chan struct{}, 64),
 	}
 }
 
@@ -41,11 +43,11 @@ func (g *Gossiper) Broadcaster() consensus.Broadcaster {
 	return g.broadcaster
 }
 
-func (g *Gossiper) RecentMessages() *lru.ARCCache {
+func (g *Gossiper) RecentMessages() *lru.LRU[common.Address, *lru.LRU[common.Hash, bool]] {
 	return g.recentMessages
 }
 
-func (g *Gossiper) KnownMessages() *lru.ARCCache {
+func (g *Gossiper) KnownMessages() *lru.LRU[common.Hash, bool] {
 	return g.knownMessages
 }
 
@@ -59,8 +61,12 @@ func (g *Gossiper) UpdateStopChannel(stopCh chan struct{}) {
 
 func (g *Gossiper) Gossip(committee types.Committee, message message.Msg) {
 	hash := message.Hash()
-	g.knownMessages.Add(hash, true)
-	targets := make(map[common.Address]struct{})
+	if !g.knownMessages.Contains(hash) {
+		g.knownMessages.Add(hash, true)
+	}
+	code := NetworkCodes[message.Code()]
+	payload := message.Payload()
+	targets := make(map[common.Address]struct{}, len(committee))
 	for _, val := range committee {
 		if val.Address != g.address {
 			targets[val.Address] = struct{}{}
@@ -69,22 +75,28 @@ func (g *Gossiper) Gossip(committee types.Committee, message message.Msg) {
 	if g.broadcaster != nil && len(targets) > 0 {
 		ps := g.broadcaster.FindPeers(targets)
 		for addr, p := range ps {
-			ms, ok := g.recentMessages.Get(addr)
-			var m *lru.ARCCache
-			if ok {
-				m, _ = ms.(*lru.ARCCache)
-				if _, k := m.Get(hash); k {
-					// This peer had this event, skip it
-					continue
+			// not needed after go1.22 - keep these for backward compatibilitiy
+			addr := addr
+			p := p
+			go func() {
+				defer func() {
+					<-g.concurrencyLimiter
+				}()
+				g.concurrencyLimiter <- struct{}{}
+				ms, ok := g.recentMessages.Get(addr)
+				if ok {
+					if ms.Contains(hash) {
+						// This peer had this event, skip it
+						return
+					}
+					ms.Add(hash, true)
+				} else {
+					ms = lru.NewLRU[common.Hash, bool](0, nil, ttlSec)
+					ms.Add(hash, true)
+					g.recentMessages.Add(addr, ms)
 				}
-			} else {
-				m, _ = lru.NewARC(inmemoryMessages)
-			}
-
-			m.Add(hash, true)
-			g.recentMessages.Add(addr, m)
-
-			go p.SendRaw(NetworkCodes[message.Code()], message.Payload()) //nolint
+				p.SendRaw(code, payload) //nolint
+			}()
 		}
 	}
 }

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -121,15 +121,15 @@ func handleConsensusMsg[T any, PT interface {
 		return true, nil // return nil to avoid shutting down connection during block sync.
 	}
 	hash := crypto.Hash(buffer.Bytes())
-	ms, ok := sb.recentMessages.Get(sender)
+	ms, ok := sb.peerKnownMessages.Get(sender)
 	if ok {
 		if !ms.Contains(hash) {
 			ms.Add(hash, true)
 		}
 	} else {
-		ms = lru.NewLRU[common.Hash, bool](0, nil, ttlSec)
+		ms = lru.NewLRU[common.Hash, bool](0, nil, ttl)
 		ms.Add(hash, true)
-		sb.recentMessages.Add(sender, ms)
+		sb.peerKnownMessages.Add(sender, ms)
 	}
 	// Mark the message known for ourselves
 	if _, ok := sb.knownMessages.Get(hash); ok {

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"io"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
 
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/consensus"
@@ -121,16 +121,16 @@ func handleConsensusMsg[T any, PT interface {
 		return true, nil // return nil to avoid shutting down connection during block sync.
 	}
 	hash := crypto.Hash(buffer.Bytes())
-	// Mark peer's message as known.
 	ms, ok := sb.recentMessages.Get(sender)
-	var m *lru.ARCCache
 	if ok {
-		m, _ = ms.(*lru.ARCCache)
+		if !ms.Contains(hash) {
+			ms.Add(hash, true)
+		}
 	} else {
-		m, _ = lru.NewARC(inmemoryMessages)
-		sb.recentMessages.Add(sender, m)
+		ms = lru.NewLRU[common.Hash, bool](0, nil, ttlSec)
+		ms.Add(hash, true)
+		sb.recentMessages.Add(sender, ms)
 	}
-	m.Add(hash, true)
 	// Mark the message known for ourselves
 	if _, ok := sb.knownMessages.Get(hash); ok {
 		return true, nil

--- a/consensus/tendermint/backend/handler_test.go
+++ b/consensus/tendermint/backend/handler_test.go
@@ -23,7 +23,7 @@ func TestTendermintMessage(t *testing.T) {
 
 	// 1. this message should not be in cache
 	// for peers
-	if _, ok := backend.recentMessages.Get(testAddress); ok {
+	if _, ok := backend.peerKnownMessages.Get(testAddress); ok {
 		t.Fatalf("the cache of messages for this peer should be nil")
 	}
 
@@ -39,7 +39,7 @@ func TestTendermintMessage(t *testing.T) {
 		t.Fatalf("handle message failed: %v", err)
 	}
 	// for peers
-	if ms, ok := backend.recentMessages.Get(testAddress); ms == nil || !ok {
+	if ms, ok := backend.peerKnownMessages.Get(testAddress); ms == nil || !ok {
 		t.Fatalf("the cache of messages for this peer cannot be nil")
 	} else if _, ok := ms.Get(data.Hash()); !ok {
 		t.Fatalf("the cache of messages for this peer cannot be found")

--- a/consensus/tendermint/backend/handler_test.go
+++ b/consensus/tendermint/backend/handler_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/autonity/autonity/consensus/tendermint/core/message"
 	"github.com/autonity/autonity/consensus/tendermint/events"
 
-	"github.com/hashicorp/golang-lru"
-
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/event"
 	"github.com/autonity/autonity/log"
@@ -43,9 +41,7 @@ func TestTendermintMessage(t *testing.T) {
 	// for peers
 	if ms, ok := backend.recentMessages.Get(testAddress); ms == nil || !ok {
 		t.Fatalf("the cache of messages for this peer cannot be nil")
-	} else if m, ok := ms.(*lru.ARCCache); !ok {
-		t.Fatalf("the cache of messages for this peer cannot be casted")
-	} else if _, ok := m.Get(data.Hash()); !ok {
+	} else if _, ok := ms.Get(data.Hash()); !ok {
 		t.Fatalf("the cache of messages for this peer cannot be found")
 	}
 

--- a/consensus/tendermint/core/interfaces/gossiper.go
+++ b/consensus/tendermint/core/interfaces/gossiper.go
@@ -1,7 +1,7 @@
 package interfaces
 
 import (
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
 
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/consensus"
@@ -14,8 +14,8 @@ type Gossiper interface {
 	AskSync(header *types.Header)
 	SetBroadcaster(broadcaster consensus.Broadcaster)
 	Broadcaster() consensus.Broadcaster
-	RecentMessages() *lru.ARCCache
-	KnownMessages() *lru.ARCCache
+	RecentMessages() *lru.LRU[common.Address, *lru.LRU[common.Hash, bool]]
+	KnownMessages() *lru.LRU[common.Hash, bool]
 	Address() common.Address
 	UpdateStopChannel(chan struct{})
 }

--- a/consensus/tendermint/core/interfaces/gossiper.go
+++ b/consensus/tendermint/core/interfaces/gossiper.go
@@ -14,7 +14,7 @@ type Gossiper interface {
 	AskSync(header *types.Header)
 	SetBroadcaster(broadcaster consensus.Broadcaster)
 	Broadcaster() consensus.Broadcaster
-	RecentMessages() *lru.LRU[common.Address, *lru.LRU[common.Hash, bool]]
+	PeerKnownMessages() *lru.LRU[common.Address, *lru.LRU[common.Hash, bool]]
 	KnownMessages() *lru.LRU[common.Hash, bool]
 	Address() common.Address
 	UpdateStopChannel(chan struct{})

--- a/consensus/tendermint/core/interfaces/gossiper_mock.go
+++ b/consensus/tendermint/core/interfaces/gossiper_mock.go
@@ -16,7 +16,7 @@ import (
 	consensus "github.com/autonity/autonity/consensus"
 	message "github.com/autonity/autonity/consensus/tendermint/core/message"
 	types "github.com/autonity/autonity/core/types"
-	lru "github.com/hashicorp/golang-lru"
+	expirable "github.com/hashicorp/golang-lru/v2/expirable"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -96,10 +96,10 @@ func (mr *MockGossiperMockRecorder) Gossip(committee, message any) *gomock.Call 
 }
 
 // KnownMessages mocks base method.
-func (m *MockGossiper) KnownMessages() *lru.ARCCache {
+func (m *MockGossiper) KnownMessages() *expirable.LRU[common.Hash, bool] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnownMessages")
-	ret0, _ := ret[0].(*lru.ARCCache)
+	ret0, _ := ret[0].(*expirable.LRU[common.Hash, bool])
 	return ret0
 }
 
@@ -110,10 +110,10 @@ func (mr *MockGossiperMockRecorder) KnownMessages() *gomock.Call {
 }
 
 // RecentMessages mocks base method.
-func (m *MockGossiper) RecentMessages() *lru.ARCCache {
+func (m *MockGossiper) RecentMessages() *expirable.LRU[common.Address, *expirable.LRU[common.Hash, bool]] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecentMessages")
-	ret0, _ := ret[0].(*lru.ARCCache)
+	ret0, _ := ret[0].(*expirable.LRU[common.Address, *expirable.LRU[common.Hash, bool]])
 	return ret0
 }
 

--- a/consensus/tendermint/core/interfaces/gossiper_mock.go
+++ b/consensus/tendermint/core/interfaces/gossiper_mock.go
@@ -95,32 +95,32 @@ func (mr *MockGossiperMockRecorder) Gossip(committee, message any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gossip", reflect.TypeOf((*MockGossiper)(nil).Gossip), committee, message)
 }
 
-// KnownMessages mocks base method.
-func (m *MockGossiper) KnownMessages() *expirable.LRU[common.Hash, bool] {
+// PeerKnownMessages mocks base method.
+func (m *MockGossiper) PeerKnownMessages() *expirable.LRU[common.Address, *expirable.LRU[common.Hash, bool]] {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KnownMessages")
-	ret0, _ := ret[0].(*expirable.LRU[common.Hash, bool])
-	return ret0
-}
-
-// KnownMessages indicates an expected call of KnownMessages.
-func (mr *MockGossiperMockRecorder) KnownMessages() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownMessages", reflect.TypeOf((*MockGossiper)(nil).KnownMessages))
-}
-
-// RecentMessages mocks base method.
-func (m *MockGossiper) RecentMessages() *expirable.LRU[common.Address, *expirable.LRU[common.Hash, bool]] {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecentMessages")
+	ret := m.ctrl.Call(m, "PeerKnownMessages")
 	ret0, _ := ret[0].(*expirable.LRU[common.Address, *expirable.LRU[common.Hash, bool]])
 	return ret0
 }
 
-// RecentMessages indicates an expected call of RecentMessages.
-func (mr *MockGossiperMockRecorder) RecentMessages() *gomock.Call {
+// PeerKnownMessages indicates an expected call of PeerKnownMessages.
+func (mr *MockGossiperMockRecorder) PeerKnownMessages() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecentMessages", reflect.TypeOf((*MockGossiper)(nil).RecentMessages))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeerKnownMessages", reflect.TypeOf((*MockGossiper)(nil).PeerKnownMessages))
+}
+
+// SelfKnownMessages mocks base method.
+func (m *MockGossiper) KnownMessages() *expirable.LRU[common.Hash, bool] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelfKnownMessages")
+	ret0, _ := ret[0].(*expirable.LRU[common.Hash, bool])
+	return ret0
+}
+
+// SelfKnownMessages indicates an expected call of SelfKnownMessages.
+func (mr *MockGossiperMockRecorder) SelfKnownMessages() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfKnownMessages", reflect.TypeOf((*MockGossiper)(nil).KnownMessages))
 }
 
 // SetBroadcaster mocks base method.

--- a/consensus/test/testcase_test.go
+++ b/consensus/test/testcase_test.go
@@ -91,6 +91,7 @@ func runTest(t *testing.T, test *testCase) {
 			goleak.IgnoreTopFunction("github.com/JekaMas/notify._Cfunc_CFRunLoopRun"),
 			goleak.IgnoreTopFunction("github.com/JekaMas/notify.(*nonrecursiveTree).internal"),
 			goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+			goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),
 			goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
 			goleak.IgnoreTopFunction("github.com/autonity/autonity/miner.(*worker).loop"),
 			goleak.IgnoreTopFunction("github.com/autonity/autonity/miner.(*worker).updater"),
@@ -162,6 +163,8 @@ func runTest(t *testing.T, test *testCase) {
 			fmt.Sprintf("127.0.0.1:%d", peer.acnPort),
 			peer.rpcPort, rates.in, rates.out)
 
+		//TODO: this causes a data race in Deploy Contract, the global bytecode for contracts
+		// is being appended to, so a concurrent access should not be done
 		wg.Go(func() error {
 			// if we have only a single validator, force mining start to bypass sync check
 			return peer.startNode(nodesNum == 1)

--- a/e2e_test/simulations/gossiper_test.go
+++ b/e2e_test/simulations/gossiper_test.go
@@ -24,7 +24,7 @@ func newCustomGossiper(b interfaces.Backend) interfaces.Gossiper {
 	return &customGossiper{
 		Gossiper:       defaultGossiper,
 		knownMessages:  defaultGossiper.KnownMessages(),
-		recentMessages: defaultGossiper.RecentMessages(),
+		recentMessages: defaultGossiper.PeerKnownMessages(),
 		address:        defaultGossiper.Address(),
 	}
 }

--- a/e2e_test/simulations/gossiper_test.go
+++ b/e2e_test/simulations/gossiper_test.go
@@ -4,8 +4,9 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 
@@ -30,8 +31,8 @@ func newCustomGossiper(b interfaces.Backend) interfaces.Gossiper {
 
 type customGossiper struct {
 	interfaces.Gossiper
-	knownMessages  *lru.ARCCache
-	recentMessages *lru.ARCCache
+	recentMessages *lru.LRU[common.Address, *lru.LRU[common.Hash, bool]] // the cache of peer's messages
+	knownMessages  *lru.LRU[common.Hash, bool]                           // the cache of self messages
 	address        common.Address
 }
 
@@ -69,19 +70,17 @@ func (cg *customGossiper) Gossip(committee types.Committee, msg message.Msg) {
 	ps := cg.Broadcaster().FindPeers(targets)
 	for addr, p := range ps {
 		ms, ok := cg.recentMessages.Get(addr)
-		var m *lru.ARCCache
 		if ok {
-			m, _ = ms.(*lru.ARCCache)
-			if _, k := m.Get(hash); k {
+			if _, k := ms.Get(hash); k {
 				// This peer had this event, skip it
 				continue
 			}
+			ms.Add(hash, true)
 		} else {
-			m, _ = lru.NewARC(1024) //   backend.inmemoryMessages  = 1024
+			ms = lru.NewLRU[common.Hash, bool](0, nil, time.Second*10)
+			ms.Add(hash, true)
+			cg.recentMessages.Add(addr, ms)
 		}
-
-		m.Add(hash, true)
-		cg.recentMessages.Add(addr, m)
 
 		go p.SendRaw(backend.NetworkCodes[msg.Code()], msg.Payload()) //nolint
 	}

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -17,12 +17,13 @@
 package eth
 
 import (
-	"github.com/autonity/autonity/accounts/abi/bind/backends"
-	"github.com/autonity/autonity/log"
 	"math"
 	"math/big"
 	"math/rand"
 	"testing"
+
+	"github.com/autonity/autonity/accounts/abi/bind/backends"
+	"github.com/autonity/autonity/log"
 
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/consensus/ethash"
@@ -46,7 +47,6 @@ var (
 	testAddr = crypto.PubkeyToAddress(testKey.PublicKey)
 )
 
-// testBackend is a mock implementation of the live Ethereum message handler. Its
 // purpose is to allow testing the request/reply workflows and wire serialization
 // in the `eth` protocol without actually doing any data processing.
 type testBackend struct {

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097 // indirect
 	github.com/kr/pretty v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=


### PR DESCRIPTION
Replace ARC cache to expirable LRU cache. Prior to this, we didnot have a period cleanup mechanisim for knownCache and recentMessages cache. Which always caused an eviction for new entries when cache was full. an Add & Eviction in ARC cache cacuses multiple deletes and addition because by desing it maintains 4 lists of entries.

This change avoids all that. All expired entries gets deleted periodically in a goroutine, which avoids eviction on every add when we receive/gossip messages.

Another fix is to delete Peer cache on unregister peer in ACN handler