### PR TITLE
fix, we don't suspend peer with network infra errors.

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -19,6 +19,8 @@ package p2p
 import (
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 )
 
 const (
@@ -114,6 +116,11 @@ func discReasonForError(err error) DiscReason {
 	if err == errProtocolReturned {
 		return DiscQuitting
 	}
+
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || strings.Contains(err.Error(), "i/o timeout") {
+		return DiscNetworkError
+	}
+
 	peerError, ok := err.(*peerError)
 	if ok {
 		switch peerError.code {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -1068,6 +1068,7 @@ func (srv *Server) checkInboundConn(remoteIP net.IP) error {
 }
 
 func (srv *Server) processPeerSuspension(pd peerDrop) {
+	// We cannot suspend peer with network infra errors.
 	reason := discReasonForError(pd.err)
 	if errors.Is(reason, DiscProtocolError) || reason == DiscSubprotocolError {
 		srv.suspended.add(pd.ID().String(), srv.currentBlock.Load()+protoErrorSuspensionSpan)


### PR DESCRIPTION
To get the network recovery from partitioning disaters, we cannot suspend peer with network infra errors.