### PR TITLE
add FastAggregateVerifyBatch

### DIFF
--- a/crypto/blst/find_invalid.go
+++ b/crypto/blst/find_invalid.go
@@ -53,8 +53,7 @@ func findInvalid(
 	wg.Add(1)
 
 	go func() {
-		aggSig := AggregateSignatures(signatures[start:pivot])
-		verified := aggSig.FastAggregateVerify(pks[start:pivot], msg)
+		verified := FastAggregateVerifyBatch(signatures[start:pivot], pks[start:pivot], msg)
 
 		if !verified {
 			leftInvalid = findInvalid(signatures, pks, msg, start, pivot)
@@ -67,8 +66,7 @@ func findInvalid(
 	wg.Add(1)
 
 	go func() {
-		aggSig := AggregateSignatures(signatures[pivot:end])
-		verified := aggSig.FastAggregateVerify(pks[pivot:end], msg)
+		verified := FastAggregateVerifyBatch(signatures[pivot:end], pks[pivot:end], msg)
 
 		if !verified {
 


### PR DESCRIPTION
Adds FastAggregateVerifyBatch. 

This new function ensures that when verifying an aggregate signature:
- if the aggregate is valid, then also all the individual signatures are valid.
- if the aggregated is invalid, then at least one signature is invalid.

The standard `FastAggregateVerify` function doesn't ensures these properties when dealing with edge cases (e.g. splitting zero attack and consensus attack. See `TestBlsAttacks` in `crypto/bls/signature_test.go` for more information).

This function however is not defined by the [BLS standard](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html), therefore **it should be checked for correctness by a cryptographer**. 

Its implementation is inspired by the `VerifyMultipleSignatures` function (which is also not present in the standard), originally proposed in https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407/14 and currently implemented in [prysm](https://github.com/prysmaticlabs/prysm/blob/develop/crypto/bls/blst/signature.go#L235)

Performance overhead is ~1% CPU more used.