### PR TITLE
[WIP] Improve spam resilience on the client

### DIFF
--- a/consensus/tendermint/accountability/fault_detector.go
+++ b/consensus/tendermint/accountability/fault_detector.go
@@ -168,7 +168,7 @@ func (fd *FaultDetector) Start() {
 	go fd.consensusMsgHandlerLoop()
 }
 
-func (fd *FaultDetector) isHeightExpired(headHeight uint64, height uint64) bool {
+func IsHeightExpired(headHeight uint64, height uint64) bool {
 	return headHeight > HeightRange && height < headHeight-HeightRange
 }
 
@@ -190,7 +190,7 @@ tendermintMsgLoop:
 			// handle consensus message or innocence proof messages
 			switch e := ev.Data.(type) {
 			case events.MessageEvent:
-				if fd.isHeightExpired(currentHeight, e.Message.H()) {
+				if IsHeightExpired(currentHeight, e.Message.H()) {
 					fd.logger.Debug("Fault detector: discarding old message")
 					continue tendermintMsgLoop
 				}
@@ -206,7 +206,7 @@ tendermintMsgLoop:
 					continue tendermintMsgLoop
 				}
 			case events.OldMessageEvent:
-				if fd.isHeightExpired(currentHeight, e.Message.H()) {
+				if IsHeightExpired(currentHeight, e.Message.H()) {
 					fd.logger.Debug("Fault detector: discarding old message")
 					continue tendermintMsgLoop
 				}

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -57,7 +57,8 @@ func New(nodeKey *ecdsa.PrivateKey,
 	services *interfaces.Services,
 	evMux *event.TypeMux,
 	ms *tendermintCore.MsgStore,
-	log log.Logger, noGossip bool) *Backend {
+	log log.Logger, noGossip bool,
+	isHeightExpired func(headHeight uint64, height uint64) bool) *Backend {
 
 	knownMessages := fixsizecache.New[common.Hash, bool](numBuckets, numEntries, fixsizecache.HashKey[common.Hash])
 
@@ -71,6 +72,7 @@ func New(nodeKey *ecdsa.PrivateKey,
 		vmConfig:        vmConfig,
 		MsgStore:        ms, //TODO: we use this only in tests, to easily reach the msg store when having a reference to the backend. It would be better to just have the `accountability` module as a part of the backend object.
 		messageCh:       make(chan events.UnverifiedMessageEvent, 1000),
+		isHeightExpired: isHeightExpired,
 		jailed:          make(map[common.Address]uint64),
 		future:          make(map[uint64][]*events.UnverifiedMessageEvent),
 		futureMinHeight: math.MaxUint64,
@@ -135,6 +137,8 @@ type Backend struct {
 	jailedLock sync.RWMutex
 
 	aggregator *aggregator
+
+	isHeightExpired func(headHeight uint64, height uint64) bool
 
 	// buffer for future height events and related metadata
 	// TODO(lorenzo) refinements, wrap this stuff into a separate struct?

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -170,9 +170,15 @@ func handleConsensusMsg[T any, PT interface {
 	}
 	// if the message is for a future height wrt to consensus engine, buffer it
 	// it will be re-injected into the handleDecodedMsg function at the right height
-	if msg.H() > sb.core.Height().Uint64() {
+	// TODO: Due to a race condition a message that is considered as future could become current, but remain stuck into the future message buffer forever
+	currentHeight := sb.core.Height().Uint64()
+	if msg.H() > currentHeight {
 		sb.logger.Debug("Saving future height consensus message for later", "msgHeight", msg.H(), "coreHeight", sb.core.Height().Uint64())
 		sb.saveFutureMsg(msg, errCh, sender)
+		return true, nil
+	}
+	// if the height is so old that it is not useful even for accountability, discard it right away. No need to waste resources on this.
+	if sb.isHeightExpired(currentHeight, msg.H()) {
 		return true, nil
 	}
 	return sb.handleDecodedMsg(msg, errCh, sender)

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -18,6 +18,7 @@
 package ethconfig
 
 import (
+	"github.com/autonity/autonity/consensus/tendermint/accountability"
 	tendermintBackend "github.com/autonity/autonity/consensus/tendermint/backend"
 	tendermintcore "github.com/autonity/autonity/consensus/tendermint/core"
 	"github.com/autonity/autonity/core/vm"
@@ -242,5 +243,5 @@ func CreateConsensusEngine(ctx *node.Node, chainConfig *params.ChainConfig, conf
 
 	nodeKey, consensusKey := ctx.Config().AutonityKeys()
 	noGossip := ctx.Config().NoGossip
-	return tendermintBackend.New(nodeKey, consensusKey, vmConfig, ctx.Config().TendermintServices(), evMux, ms, ctx.Logger(), noGossip)
+	return tendermintBackend.New(nodeKey, consensusKey, vmConfig, ctx.Config().TendermintServices(), evMux, ms, ctx.Logger(), noGossip, accountability.IsHeightExpired)
 }


### PR DESCRIPTION
Improvements:
- if a message is so old that it is not useful even for accountability, discard it right away without verifying it.

## TODO
###  future height message spam 
 A future height message spam can cause two problems:
1. slight increase in CPU usage (however not really significant from the test I ran)
2. eviction of future messages received from honest nodes. I.e. the spammer spams so many messages that the cache fills and we start removing useful messages.

Solution: 
1. Discard messages that are so far in the future that they belong to the next epoch. If we receive messages for the next epoch it means that either we are very out of sync, or that someone is spamming. In any case it is safe to discard those messages (but removing them from the knownMessage cache, so that we can re-receive them). Depends on https://github.com/autonity/autonity/pull/1009 to easily determine epoch end.
2. Partition the future height messages buffer based on the sender (`p2pAddress`). This way a spammer will not cause eviction of messages received by other peers. 

With these two mitigations in place we will ensure that honest peers messages will not be evicted from the buffer + the spamming node will likely be slashed and he cannot unbond before that (because we do not accept messages that do not belong to the current epoch).

### spam of current/old messages from jailed validator

We will make the signature group check and the PreValidate before discarding the message because it comes from a jailed validators. These are wasted resources.

Solution:
- P2p suspend jailed validators until the end of the epoch. The in the following epoch they will be evicted from the committee, so we will not be connected to them anymore. Depends on https://github.com/autonity/autonity/pull/1009 to easily determine epoch end.

However note that messages from a jailed validator can still arrive to us from another colluding peer which gossips them even if the signer is jailed. 

### additional metrics 

Add metrics for jailings and p2p suspends.