### PR TITLE
Fix asm tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,8 @@ test-contracts-asm-pre:
 	@cd $(CONTRACTS_BASE_DIR) && npm list hardhat@$(HARDHAT_VERSION) > /dev/null || npm install hardhat@$(HARDHAT_VERSION)
 	@echo "install ape framework plugins"
 	@cd $(CONTRACTS_BASE_DIR) && ape plugins install -y --verbosity ERROR .
+	@echo "pin version of numpy to 1.26.4"
+	@pip install --force-reinstall -v "numpy==1.26.4"	
 	@echo "dependencies installed"
 
 # start an autonity network for contract tests

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ test-contracts-asm-pre:
 	@echo "check and install ape framework"
 	@ape > /dev/null || pipx install eth-ape==$(APE_VERSION) || { pipx uninstall eth-ape; exit 1; }
 	@echo "pin version of numpy to 1.26.4"
-	@pipx inject --verbose eth-ape numpy==1.26.4
+	@pipx inject --verbose --force eth-ape numpy==1.26.4
 	@echo "check ape framework version"
 	@test $$(ape --version) = "$(APE_VERSION)" || { \
 		echo -n "error: unsupported ape version $$(ape --version) "; \

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,8 @@ test-contracts-asm: test-contracts-asm-pre
 test-contracts-asm-pre:
 	@echo "check and install ape framework"
 	@ape > /dev/null || pipx install eth-ape==$(APE_VERSION) || { pipx uninstall eth-ape; exit 1; }
+	@echo "pin version of numpy to 1.26.4"
+	@pip install --force-reinstall -v "numpy==1.26.4"	
 	@echo "check ape framework version"
 	@test $$(ape --version) = "$(APE_VERSION)" || { \
 		echo -n "error: unsupported ape version $$(ape --version) "; \
@@ -193,8 +195,6 @@ test-contracts-asm-pre:
 	@cd $(CONTRACTS_BASE_DIR) && npm list hardhat@$(HARDHAT_VERSION) > /dev/null || npm install hardhat@$(HARDHAT_VERSION)
 	@echo "install ape framework plugins"
 	@cd $(CONTRACTS_BASE_DIR) && ape plugins install -y --verbosity ERROR .
-	@echo "pin version of numpy to 1.26.4"
-	@pip install --force-reinstall -v "numpy==1.26.4"	
 	@echo "dependencies installed"
 
 # start an autonity network for contract tests

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ test-contracts-asm-pre:
 	@echo "check and install ape framework"
 	@ape > /dev/null || pipx install eth-ape==$(APE_VERSION) || { pipx uninstall eth-ape; exit 1; }
 	@echo "pin version of numpy to 1.26.4"
-	@pip install --force-reinstall -v "numpy==1.26.4"	
+	@pipx inject --verbose eth-ape numpy==1.26.4
 	@echo "check ape framework version"
 	@test $$(ape --version) = "$(APE_VERSION)" || { \
 		echo -n "error: unsupported ape version $$(ape --version) "; \


### PR DESCRIPTION
Pin numpy version to 1.26.4. See https://github.com/numpy/numpy/issues/26710 and  https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from