### PR TITLE
Generate NatSpec data together with contract ABIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ __pycache__/
 /package.json
 /params/generated/**/*.abi
 /params/generated/**/*.bin
+/params/generated/**/*.docdev
+/params/generated/**/*.docuser
 nohup.out
 
 # travis

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ autonity-docker:
 	@echo "Run \"$(BINDIR)/autonity\" to launch autonity."
 
 define gen-contract
-	$(SOLC_BINARY) --overwrite --optimize --optimize-runs 10000 --evm-version london --abi --bin -o $(GENERATED_CONTRACT_DIR) $(CONTRACTS_DIR)/$(1)$(2).sol
+	$(SOLC_BINARY) --overwrite --optimize --optimize-runs 10000 --evm-version london --abi --bin --userdoc --devdoc -o $(GENERATED_CONTRACT_DIR) $(CONTRACTS_DIR)/$(1)$(2).sol
 
 	@echo Generating bytecode for $(2)
 	@echo 'package generated' > $(GENERATED_CONTRACT_DIR)/$(2).go
@@ -291,7 +291,7 @@ lint-deps:
 clean:
 	go clean -cache
 	rm -fr build/_workspace/pkg/ $(BINDIR)/*
-	rm -rf $(GENERATED_CONTRACT_DIR)/*.abi $(GENERATED_CONTRACT_DIR)/*.bin
+	rm -rf $(GENERATED_CONTRACT_DIR)/*.abi $(GENERATED_CONTRACT_DIR)/*.bin $(GENERATED_CONTRACT_DIR)/*.doc*
 
 # The devtools target installs tools required for 'go generate'.
 # You need to put $BINDIR (or $GOPATH/bin) in your PATH to use 'go generate'.


### PR DESCRIPTION
Currently, the protocol contract documentation is maintained manually in the [docs.autonity.org repository](https://github.com/autonity/docs.autonity.org).

As part of the documentation effort for mainnet launch, we are planning to [migrate protocol contract documentation to the source code](https://github.com/autonity/docs.autonity.org/issues/217) and [automatically generate documentation from NatSpec data](https://github.com/autonity/docs.autonity.org/issues/216).

Using the existing Autonity build process for [generating NatSpec files](https://docs.soliditylang.org/en/latest/natspec-format.html#documentation-output) would reduce the maintenance burden on the documentation generator, compared to maintaining a similar Makefile in the docs repository. With the `--userdoc` and `--devdoc` Solc compiler options the NatSpec JSONs will be available next to the ABI files with `.docdev` and `.docuser` file extensions that can be used as inputs to the generator.