### PR TITLE
fix aggregator height/round map cleanup

### DIFF
--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -905,7 +905,6 @@ loop:
 							signatureInput := sameValueVotes[0].Message.SignatureInput() // all votes have same (h,r,c,v)
 							a.staleMessages[signatureInput] = append(a.staleMessages[signatureInput], sameValueVotes...)
 						}
-
 						delete(a.messages[h], r)
 						roundMapSize.Dec(1)
 						continue

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -42,6 +42,8 @@ var (
 	BatchesBg                  = metrics.NewRegisteredBufferedGauge("aggregator/batches", nil, metrics.GetIntPointer(100))          // size of batches (aggregated together with a single fastAggregateVerify)
 	InvalidBg                  = metrics.NewRegisteredBufferedGauge("aggregator/invalid", nil, metrics.GetIntPointer(100))          // number of invalid sigs
 	BackendAggregatorTransitBg = metrics.NewRegisteredBufferedGauge("aggregator/backend/transit", nil, metrics.GetIntPointer(1000)) // measures time for message passing from backend to aggregator
+	roundMapSize               = metrics.NewRegisteredGauge("aggregator/rounds/all", nil)
+	heightMapSize              = metrics.NewRegisteredGauge("aggregator/height/all", nil)
 )
 
 func recordMessageProcessingTime(code uint8, start time.Time) {
@@ -184,10 +186,12 @@ func (a *aggregator) saveMessage(e events.UnverifiedMessageEvent) {
 
 	if _, ok := a.messages[h]; !ok {
 		a.messages[h] = make(map[int64]*RoundInfo)
+		heightMapSize.Inc(1)
 	}
 
 	if _, ok := a.messages[h][r]; !ok {
 		a.messages[h][r] = NewRoundInfo()
+		roundMapSize.Inc(1)
 	}
 
 	roundInfo := a.messages[h][r]
@@ -324,8 +328,11 @@ func (a *aggregator) processRound(h uint64, r int64) {
 
 	a.processBatches(batches, currentHeightEventBuilder)
 
-	//clean up
-	delete(a.messages[h], r)
+	if _, ok := a.messages[h][r]; ok {
+		//clean up
+		delete(a.messages[h], r)
+		roundMapSize.Dec(1)
+	}
 }
 
 func (a *aggregator) processVotes(h uint64, r int64, c uint8) {
@@ -898,11 +905,17 @@ loop:
 							signatureInput := sameValueVotes[0].Message.SignatureInput() // all votes have same (h,r,c,v)
 							a.staleMessages[signatureInput] = append(a.staleMessages[signatureInput], sameValueVotes...)
 						}
+
 						delete(a.messages[h], r)
+						roundMapSize.Dec(1)
 						continue
 					}
 					// if current height, process them
 					a.processRound(h, r)
+				}
+				if h < coreHeight {
+					delete(a.messages, h)
+					heightMapSize.Dec(1)
 				}
 			}
 			// cleanup

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -40,8 +40,8 @@ const (
 	// while asking sync for consensus messages, if we do not find any peers we try again after 10 ms
 	retryPeriod = 10
 	// number of buckets to allocate in the fixed cache
-	numBuckets = 499
-	// max number of entries in each packet
+	numBuckets = 4999
+	// max number of entries in each bucket
 	numEntries = 10
 )
 

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -70,7 +70,7 @@ func New(nodeKey *ecdsa.PrivateKey,
 		knownMessages:   knownMessages,
 		vmConfig:        vmConfig,
 		MsgStore:        ms, //TODO: we use this only in tests, to easily reach the msg store when having a reference to the backend. It would be better to just have the `accountability` module as a part of the backend object.
-		messageCh:       make(chan events.UnverifiedMessageEvent, 1000),
+		messageCh:       make(chan events.UnverifiedMessageEvent, 5000),
 		jailed:          make(map[common.Address]uint64),
 		future:          make(map[uint64][]*events.UnverifiedMessageEvent),
 		futureMinHeight: math.MaxUint64,

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -215,7 +215,6 @@ func (sb *Backend) handleDecodedMsg(msg message.Msg, errCh chan<- error, sender 
 		sb.logger.Crit("Tendermint backend processing unknown message")
 	}
 
-	//TODO: remove this
 	sb.Post(events.UnverifiedMessageEvent{
 		Message: msg,
 		ErrCh:   errCh,

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -215,7 +215,8 @@ func (sb *Backend) handleDecodedMsg(msg message.Msg, errCh chan<- error, sender 
 		sb.logger.Crit("Tendermint backend processing unknown message")
 	}
 
-	go sb.Post(events.UnverifiedMessageEvent{
+	//TODO: remove this
+	sb.Post(events.UnverifiedMessageEvent{
 		Message: msg,
 		ErrCh:   errCh,
 		Sender:  sender,


### PR DESCRIPTION
Piccadilly issue - Number of goroutines kept growing due to aggregator being busy in iterating over height Map.
Changed few things:
1. remove goroutine in backend and increase the size of buffered message ch
2. increase fixSize cache capacity
3. Fix clean up of message map in aggregator

