### PR TITLE
port hotfixes from v14 release

### DIFF
--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -898,6 +898,9 @@ loop:
 					// if current height, process them
 					a.processRound(h, r)
 				}
+				if h < coreHeight {
+					delete(a.messages, h)
+				}
 			}
 			// cleanup
 			a.messagesFrom = make(map[common.Address][]common.Hash)

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -39,7 +39,7 @@ const (
 	// while asking sync for consensus messages, if we do not find any peers we try again after 10 ms
 	retryPeriod = 10
 	// number of buckets to allocate in the fixed cache
-	numBuckets = 499
+	numBuckets = 1999
 	// max number of entries in each packet
 	numEntries = 10
 )
@@ -69,7 +69,7 @@ func New(nodeKey *ecdsa.PrivateKey,
 		knownMessages:   knownMessages,
 		vmConfig:        vmConfig,
 		MsgStore:        ms, //TODO: we use this only in tests, to easily reach the msg store when having a reference to the backend. It would be better to just have the `accountability` module as a part of the backend object.
-		messageCh:       make(chan events.UnverifiedMessageEvent, 1000),
+		messageCh:       make(chan events.UnverifiedMessageEvent, 5000),
 		jailed:          make(map[common.Address]uint64),
 		future:          make(map[uint64][]*events.UnverifiedMessageEvent),
 		futureMinHeight: math.MaxUint64,

--- a/consensus/tendermint/backend/gossiper.go
+++ b/consensus/tendermint/backend/gossiper.go
@@ -14,21 +14,19 @@ import (
 )
 
 type Gossiper struct {
-	knownMessages      *fixsizecache.Cache[common.Hash, bool] // the cache of self messages
-	address            common.Address                         // address of the local peer
-	broadcaster        consensus.Broadcaster
-	logger             log.Logger
-	stopped            chan struct{}
-	concurrencyLimiter chan struct{}
+	knownMessages *fixsizecache.Cache[common.Hash, bool] // the cache of self messages
+	address       common.Address                         // address of the local peer
+	broadcaster   consensus.Broadcaster
+	logger        log.Logger
+	stopped       chan struct{}
 }
 
 func NewGossiper(knownMessages *fixsizecache.Cache[common.Hash, bool], address common.Address, logger log.Logger, stopped chan struct{}) *Gossiper {
 	return &Gossiper{
-		knownMessages:      knownMessages,
-		address:            address,
-		logger:             logger,
-		stopped:            stopped,
-		concurrencyLimiter: make(chan struct{}, 64),
+		knownMessages: knownMessages,
+		address:       address,
+		logger:        logger,
+		stopped:       stopped,
 	}
 }
 
@@ -72,13 +70,7 @@ func (g *Gossiper) Gossip(committee *types.Committee, message message.Msg) {
 				continue
 			}
 			p.Cache().Add(hash, true)
-			g.concurrencyLimiter <- struct{}{}
-			go func() {
-				defer func() {
-					<-g.concurrencyLimiter
-				}()
-				p.SendRaw(code, payload) //nolint
-			}()
+			go p.SendRaw(code, payload) //nolint
 		}
 	}
 }

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -213,7 +213,7 @@ func (sb *Backend) handleDecodedMsg(msg message.Msg, errCh chan<- error, sender 
 		sb.logger.Crit("Tendermint backend processing unknown message")
 	}
 
-	go sb.Post(events.UnverifiedMessageEvent{
+	sb.Post(events.UnverifiedMessageEvent{
 		Message: msg,
 		ErrCh:   errCh,
 		Sender:  sender,


### PR DESCRIPTION
-  concurrency limiter
-  agggregator map bug fix
-  remove go routine b/w acn and aggregator, use large buffered channel