### PR TITLE
fix, do not trigger the optimistic parent block's logs on child blocks.

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -625,6 +625,9 @@ func (w *worker) resultLoop() {
 				continue
 			}
 
+			// The logs inside the task.env.state may contain parent block's logs as we copied the parent state when
+			// making environment for the child of an optimistic parent block for consensus pipeline optimization.
+			// Thus, we construct logs from the task.env.receipts that is unique for block.
 			var logs []*types.Log
 			// Update the block hash in all logs since it is now available and not when the
 			// receipt/log of individual transactions were created.
@@ -676,6 +679,8 @@ func (w *worker) makeEnv(parent *types.Block, header *types.Header, coinbase com
 		hash  common.Hash
 	)
 	if optimisticCandidate {
+		// copying the cached parent block's state for current block's assembling.
+		// It also copies the logs of the txn receipts of the parent block.
 		if parent.Header().Coinbase == w.coinbase { // we were the proposer for the parent
 			sealHash := w.engine.SealHash(parent.Header())
 			w.pendingMu.Lock()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -679,8 +679,7 @@ func (w *worker) makeEnv(parent *types.Block, header *types.Header, coinbase com
 		hash  common.Hash
 	)
 	if optimisticCandidate {
-		// copying the cached parent block's state for current block's assembling.
-		// It also copies the logs of the txn receipts of the parent block.
+		// Making environment by coping cached optimistic parent block's state also copies the receipt logs.
 		if parent.Header().Coinbase == w.coinbase { // we were the proposer for the parent
 			sealHash := w.engine.SealHash(parent.Header())
 			w.pendingMu.Lock()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -627,6 +627,8 @@ func (w *worker) resultLoop() {
 
 			// The logs inside the task.env.state may contain parent block's logs as we copied the parent state when
 			// making environment for the child of an optimistic parent block for consensus pipeline optimization.
+			// Thus, we do a deep copies of receipts and logs from the task's execution environment, and update the
+			// corresponding block location without modifying the source task environment.
 			var (
 				receipts = make([]*types.Receipt, len(task.env.receipts))
 				logs     []*types.Log

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -627,37 +627,26 @@ func (w *worker) resultLoop() {
 
 			// The logs inside the task.env.state may contain parent block's logs as we copied the parent state when
 			// making environment for the child of an optimistic parent block for consensus pipeline optimization.
-			// Thus, we do a deep copies of receipts and logs from the task's execution environment, and update the
-			// corresponding block location without modifying the source task environment.
-			var (
-				receipts = make([]*types.Receipt, len(task.env.receipts))
-				logs     []*types.Log
-			)
-			for i, taskReceipt := range task.env.receipts {
-				receipt := new(types.Receipt)
-				receipts[i] = receipt
-				*receipt = *taskReceipt
+			// Thus, we just deep copy logs from the receipts of the current block execution environment.
+			var logs []*types.Log
 
-				// add block location fields
-				receipt.BlockHash = hash
-				receipt.BlockNumber = block.Number()
-				receipt.TransactionIndex = uint(i)
-
-				// Update the block hash in all logs since it is now available and not when the
-				// receipt/log of individual transactions were created.
-				receipt.Logs = make([]*types.Log, len(taskReceipt.Logs))
-				for i, taskLog := range taskReceipt.Logs {
-					l := new(types.Log)
-					receipt.Logs[i] = l
-					*l = *taskLog
-					l.BlockHash = hash
+			// Update the block hash in all logs since it is now available and not when the
+			// receipt/log of individual transactions were created.
+			for i, r := range task.env.receipts {
+				r.BlockHash = block.Hash()
+				r.BlockNumber = block.Number()
+				r.TransactionIndex = uint(i)
+				for _, l := range r.Logs {
+					l.BlockHash = block.Hash()
 				}
-				logs = append(logs, receipt.Logs...)
+				logs = append(logs, r.Logs...)
 			}
 
 			// Commit block and state to database.
 			persistStart := time.Now()
-			_, err := w.chain.WriteBlockAndSetHead(block, receipts, logs, task.env.state, true)
+
+			// As the environment is no longer used anymore, we won't copy the receipts to announce the new block.
+			_, err := w.chain.WriteBlockAndSetHead(block, task.env.receipts, logs, task.env.state, true)
 			if err != nil {
 				w.eth.Logger().Error("Failed writing block to chain", "err", err)
 				continue

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -627,26 +627,35 @@ func (w *worker) resultLoop() {
 
 			// The logs inside the task.env.state may contain parent block's logs as we copied the parent state when
 			// making environment for the child of an optimistic parent block for consensus pipeline optimization.
-			// Thus, we construct logs from the task.env.receipts that is unique for block.
-			var logs []*types.Log
-			// Update the block hash in all logs since it is now available and not when the
-			// receipt/log of individual transactions were created.
-			for i, r := range task.env.receipts {
-				r.BlockHash = block.Hash()
-				r.BlockNumber = block.Number()
-				r.TransactionIndex = uint(i)
-				for i, taskLog := range r.Logs {
+			var (
+				receipts = make([]*types.Receipt, len(task.env.receipts))
+				logs     []*types.Log
+			)
+			for i, taskReceipt := range task.env.receipts {
+				receipt := new(types.Receipt)
+				receipts[i] = receipt
+				*receipt = *taskReceipt
+
+				// add block location fields
+				receipt.BlockHash = hash
+				receipt.BlockNumber = block.Number()
+				receipt.TransactionIndex = uint(i)
+
+				// Update the block hash in all logs since it is now available and not when the
+				// receipt/log of individual transactions were created.
+				receipt.Logs = make([]*types.Log, len(taskReceipt.Logs))
+				for i, taskLog := range taskReceipt.Logs {
 					l := new(types.Log)
-					r.Logs[i] = l
+					receipt.Logs[i] = l
 					*l = *taskLog
-					taskLog.BlockHash = block.Hash()
+					l.BlockHash = hash
 				}
-				logs = append(logs, r.Logs...)
+				logs = append(logs, receipt.Logs...)
 			}
 
 			// Commit block and state to database.
 			persistStart := time.Now()
-			_, err := w.chain.WriteBlockAndSetHead(block, task.env.receipts, logs, task.env.state, true)
+			_, err := w.chain.WriteBlockAndSetHead(block, receipts, logs, task.env.state, true)
 			if err != nil {
 				w.eth.Logger().Error("Failed writing block to chain", "err", err)
 				continue

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -625,20 +625,25 @@ func (w *worker) resultLoop() {
 				continue
 			}
 
+			var logs []*types.Log
 			// Update the block hash in all logs since it is now available and not when the
 			// receipt/log of individual transactions were created.
 			for i, r := range task.env.receipts {
 				r.BlockHash = block.Hash()
 				r.BlockNumber = block.Number()
 				r.TransactionIndex = uint(i)
-				for _, l := range r.Logs {
-					l.BlockHash = block.Hash()
+				for i, taskLog := range r.Logs {
+					l := new(types.Log)
+					r.Logs[i] = l
+					*l = *taskLog
+					taskLog.BlockHash = block.Hash()
 				}
+				logs = append(logs, r.Logs...)
 			}
 
 			// Commit block and state to database.
 			persistStart := time.Now()
-			_, err := w.chain.WriteBlockAndSetHead(block, task.env.receipts, task.env.state.Logs(), task.env.state, true)
+			_, err := w.chain.WriteBlockAndSetHead(block, task.env.receipts, logs, task.env.state, true)
 			if err != nil {
 				w.eth.Logger().Error("Failed writing block to chain", "err", err)
 				continue


### PR DESCRIPTION
This PR fix the duplicated TXN log notification on the client when making environment for the child block of an optimistic parent block for consensus pipeline optimization.