### PR TITLE
fix, oracle accountability slashing is reverted.

### DIFF
--- a/autonity/solidity/contracts/Autonity.sol
+++ b/autonity/solidity/contracts/Autonity.sol
@@ -1249,7 +1249,9 @@ contract Autonity is IAutonity, IERC20, ReentrancyGuard, ScheduleController, Upg
     * This should be abstracted by a separate smart-contract.
     */
     modifier onlyAccountability {
-        require(address(config.contracts.accountabilityContract) == msg.sender || address(config.contracts.omissionAccountabilityContract) == msg.sender, "caller is not an accountability contract");
+        require(address(config.contracts.accountabilityContract) == msg.sender
+        || address(config.contracts.omissionAccountabilityContract) == msg.sender
+        || address(config.contracts.oracleContract) == msg.sender, "caller is not an accountability contract");
         _;
     }
 

--- a/autonity/solidity/contracts/Oracle.sol
+++ b/autonity/solidity/contracts/Oracle.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.2 < 0.9.0;
 import "./interfaces/IOracle.sol";
 import "./Autonity.sol";
 import {EnumerableSet} from "./utils/AddressSet.sol";
+import {ORACLE_SLASHING_RATE_CAP} from "./ProtocolConstants.sol";
 
 /**
  * @title Autonity Protocol - Oracle Contract
@@ -638,11 +639,16 @@ contract Oracle is IOracle {
             return;
         }
 
-        //TODO: this slashing rate computing can result an >= SLASHING_RATE_PRECISION (10,000) rate,
-        //  which means a >= 100% slashing, we need to evaluate the correctness of this formula.
+        // TODO: to formal evaluate the correctness of this formula.
         uint256 _slashingRate = uint256(_diffRatio - config.outlierSlashingThreshold) *
                                uint256(_report.confidence) *
                                config.baseSlashingRate; // some scaling is prob needed here.
+
+        // Capped the oracle slashing rate
+        if (_slashingRate > ORACLE_SLASHING_RATE_CAP) {
+            _slashingRate = ORACLE_SLASHING_RATE_CAP;
+        }
+
         config.autonity.slash(voterInfo[_outlier].validator, _slashingRate);
     }
 

--- a/autonity/solidity/contracts/Oracle.sol
+++ b/autonity/solidity/contracts/Oracle.sol
@@ -638,6 +638,8 @@ contract Oracle is IOracle {
             return;
         }
 
+        //TODO: this slashing rate computing can result an >= SLASHING_RATE_PRECISION (10,000) rate,
+        //  which means a >= 100% slashing, we need to evaluate the correctness of this formula.
         uint256 _slashingRate = uint256(_diffRatio - config.outlierSlashingThreshold) *
                                uint256(_report.confidence) *
                                config.baseSlashingRate; // some scaling is prob needed here.

--- a/autonity/solidity/contracts/ProtocolConstants.sol
+++ b/autonity/solidity/contracts/ProtocolConstants.sol
@@ -2,4 +2,5 @@
 pragma solidity ^0.8.19;
 
 uint256 constant SLASHING_RATE_PRECISION = 10_000; // 100% slashing rate.
-uint256 constant ORACLE_SLASHING_RATE_CAP = 1_000; // Capped with 10% slashing rate.
+// Todo: resolve a better cap for the protocol.
+uint256 constant ORACLE_SLASHING_RATE_CAP = 1_000; // Capped with 10% slashing rate for oracle accountability.

--- a/autonity/solidity/contracts/ProtocolConstants.sol
+++ b/autonity/solidity/contracts/ProtocolConstants.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.19;
 
-uint256 constant SLASHING_RATE_PRECISION = 10_000;
+uint256 constant SLASHING_RATE_PRECISION = 10_000; // 100% slashing rate.
+uint256 constant ORACLE_SLASHING_RATE_CAP = 1_000; // Capped with 10% slashing rate.

--- a/autonity/solidity/contracts/Slasher.sol
+++ b/autonity/solidity/contracts/Slasher.sol
@@ -77,23 +77,6 @@ contract Slasher {
         Autonity.Validator memory,
         uint256
     ){
-        // Todo: discuss if it is too crucial for oracle network?
-        // As oracle accountability can compute >= 100% slashing rate,  in case of >= 100% slash,
-        // slash all funds and jailbound validator.
-        if (_slashingRate >= SLASHING_RATE_PRECISION) {
-            uint256 _availableFunds = _val.bondedStake + _val.unbondingStake + _val.selfUnbondingStake;
-            if (_availableFunds == 0) {
-                return (_val, _availableFunds);
-            }
-            _val.bondedStake = 0;
-            _val.selfBondedStake = 0;
-            _val.selfUnbondingStake = 0;
-            _val.unbondingStake = 0;
-            _val.totalSlashed += _availableFunds;
-            //_jailbound(_val, _newJailboundState); // shall we do this jailBound?
-            return (_val, _availableFunds);
-        }
-
         uint256 _slashingAmount = _slash(_val, _slashingRate);
         return (_val, _slashingAmount);
     }

--- a/autonity/solidity/contracts/Slasher.sol
+++ b/autonity/solidity/contracts/Slasher.sol
@@ -77,6 +77,23 @@ contract Slasher {
         Autonity.Validator memory,
         uint256
     ){
+        // Todo: discuss if it is too crucial for oracle network?
+        // As oracle accountability can compute >= 100% slashing rate,  in case of >= 100% slash,
+        // slash all funds and jailbound validator.
+        if (_slashingRate >= SLASHING_RATE_PRECISION) {
+            uint256 _availableFunds = _val.bondedStake + _val.unbondingStake + _val.selfUnbondingStake;
+            if (_availableFunds == 0) {
+                return (_val, _availableFunds);
+            }
+            _val.bondedStake = 0;
+            _val.selfBondedStake = 0;
+            _val.selfUnbondingStake = 0;
+            _val.unbondingStake = 0;
+            _val.totalSlashed += _availableFunds;
+            //_jailbound(_val, _newJailboundState); // shall we do this jailBound?
+            return (_val, _availableFunds);
+        }
+
         uint256 _slashingAmount = _slash(_val, _slashingRate);
         return (_val, _slashingAmount);
     }


### PR DESCRIPTION
This PR contain a few corrections for oracle accountability slashing logics.

- [x] grant the autonity.slash() access to oracle contract
- [x] process the over 100% slashing rate for oracle accountability.

**TODO:** The slashing rate computing can result a >= SLASHING_RATE_PRECISION (10,000) rate, which means a >= 100% slashing, we need to evaluate the correctness of the computing formula.

@lorenzo-dev1 please help to double check the changes in the Slasher.sol contract. I just added an processing of an edge case for it. 
