### PR TITLE
fix api to fetch acn peer infos

### DIFF
--- a/e2e_test/api_test.go
+++ b/e2e_test/api_test.go
@@ -34,7 +34,7 @@ func TestAPI_AcnPeers(t *testing.T) {
 	require.NoError(t, err)
 
 	// test json un-marshaling
-	var result  []*p2p.PeerInfo
+	var result []*p2p.PeerInfo
 	err = json.Unmarshal(jsonPayload, &result)
 	require.NoError(t, err)
 	for _, peer := range result {

--- a/e2e_test/api_test.go
+++ b/e2e_test/api_test.go
@@ -1,0 +1,43 @@
+package e2e
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autonity/autonity/eth"
+	"github.com/autonity/autonity/p2p"
+)
+
+func TestAPI_AcnPeers(t *testing.T) {
+	network, err := NewNetwork(t, 7, "10e18,v,1,0.0.0.0:%s,%s,%s,%s")
+	require.NoError(t, err)
+	defer network.Shutdown(t)
+	err = network.WaitToMineNBlocks(5, 30, false)
+	require.NoError(t, err)
+	node := network[0]
+	apis := node.Eth.APIs()
+	var autContractAPI *eth.AutonityContractAPI
+	for _, api := range apis {
+		if api.Namespace == "aut" {
+			autContractAPI = api.Service.(*eth.AutonityContractAPI)
+			break
+		}
+	}
+	require.NotNil(t, autContractAPI)
+	peers := autContractAPI.AcnPeers()
+	require.Equal(t, len(network)-1, len(peers))
+
+	// test json marshaling
+	jsonPayload, err := json.Marshal(peers)
+	require.NoError(t, err)
+
+	// test json un-marshaling
+	var result  []*p2p.PeerInfo
+	err = json.Unmarshal(jsonPayload, &result)
+	require.NoError(t, err)
+	for _, peer := range result {
+		require.True(t, peer.Network.Trusted)
+	}
+}

--- a/eth/api.go
+++ b/eth/api.go
@@ -630,8 +630,8 @@ func (a *AutonityContractAPI) Address() common.Address {
 	return params.AutonityContractAddress
 }
 
-func (a *AutonityContractAPI) AcnPeers() []*p2p.Peer {
-	return a.server.Peers()
+func (a *AutonityContractAPI) AcnPeers() []*p2p.PeerInfo {
+	return a.server.PeersInfo()
 }
 
 // NewAutonityContractAPI builds a map of function name to method representing


### PR DESCRIPTION
The wrong type was returned which didn't have any json tags either. so result was not displayed properly. Fixed the return type add test to make sure Json marshalling/unmarshalling is successful.