### PR TITLE
Fix Prometheus metrics format

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -53,7 +53,7 @@ import (
 var (
 	headBlockGauge       = metrics.NewRegisteredGauge("chain/head/block", nil)
 	headHeaderGauge      = metrics.NewRegisteredGauge("chain/head/header", nil)
-	headEpochHeaderGauge = metrics.NewRegisteredGauge("chain/head/epoch-header", nil)
+	headEpochHeaderGauge = metrics.NewRegisteredGauge("chain/head/epoch/header", nil)
 	headFastBlockGauge   = metrics.NewRegisteredGauge("chain/head/receipt", nil)
 
 	accountReadTimer   = metrics.NewRegisteredTimer("chain/account/reads", nil)


### PR DESCRIPTION
This solves https://github.com/autonity/autonity/issues/1111

This fixes incorrect type of this metric
```
# TYPE chain_head_epoch-header gauge
```
to
```
# TYPE chain_head_epoch_header gauge
```

I deployed this fix to one of our nodes and our Prometheus instance can now scrape metrics from this node.

As per https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels regex for allowed names does not contain `-` - `[a-zA-Z_:][a-zA-Z0-9_:]*`

