### PR TITLE
bug correction, epoch finalization failure due to a wrong contract ad…

### DIFF
--- a/autonity/calls.go
+++ b/autonity/calls.go
@@ -314,6 +314,7 @@ func DeployAutonityContract(genesisConfig *params.AutonityContractGenesis, genes
 			UpgradeManagerContract:         params.UpgradeManagerContractAddress,
 			InflationControllerContract:    params.InflationControllerContractAddress,
 			OmissionAccountabilityContract: params.OmissionAccountabilityContractAddress,
+			LatencyContract:                params.LatencyContractAddress,
 		},
 		Protocol: AutonityProtocol{
 			OperatorAccount:     genesisConfig.Operator,


### PR DESCRIPTION
This PR contains a correction to fix the epoch block finalization failure due to an un-initialize latency contract address.