### PR TITLE
Migrate to actions/cache@v4 and fix ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: gocache
         with:
           path: |
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -126,7 +126,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -153,7 +153,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -206,7 +206,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -239,7 +239,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -271,7 +271,7 @@ jobs:
         with:
           fetch-depth: '2'
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -295,7 +295,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -320,7 +320,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -345,7 +345,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -370,7 +370,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -395,7 +395,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}
@@ -420,7 +420,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GO_CACHE }}


### PR DESCRIPTION
CI was broken, see https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down and https://github.com/actions/toolkit/discussions/1890 and https://github.com/actions/cache/discussions/1510