### PR TITLE
enable peer consensus endpoint check on receiving inbound connection

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -78,9 +78,9 @@ const (
 	DiscPeerNotInCommittee
 	DiscPeerOutsideTopology
 	DiscSyncFailed
-	DiscSubprotocolError = 0x10
-
-	DiscInvalid = 0xff
+	DiscACNPeerNotReachable
+	DiscSubprotocolError = 0x11
+	DiscInvalid          = 0xff
 )
 
 var discReasonToString = [...]string{
@@ -100,6 +100,7 @@ var discReasonToString = [...]string{
 	DiscPeerNotInCommittee:  "validator is not part of committee",
 	DiscPeerOutsideTopology: "peer outside topology",
 	DiscSyncFailed:          "failed to sync with remote peer",
+	DiscACNPeerNotReachable: "peer consensus endpoint is not reachable",
 	DiscSubprotocolError:    "subprotocol error",
 	DiscInvalid:             "invalid disconnect reason",
 }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -980,7 +980,7 @@ func (srv *Server) postHandshakeChecks(peers map[enode.ID]*Peer, inboundCount in
 		return DiscPeerNotInCommittee
 	case srv.Net == Execution && srv.inCommittee(c.node.ID()) && !srv.inCommitteeSubset(c.node.ID()):
 		return DiscPeerOutsideTopology
-	case srv.Net == Consensus && !srv.isConsensusEndpointReachable(c.node.ID()):
+	case srv.Net == Consensus && c.is(inboundConn) && !srv.isConsensusEndpointReachable(c.node.ID()):
 		return DiscACNPeerNotReachable
 	default:
 		return nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -29,8 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/common/mclock"
 	"github.com/autonity/autonity/crypto"
@@ -471,23 +469,28 @@ func (srv *Server) inCommittee(id enode.ID) bool {
 }
 
 func (srv *Server) isConsensusEndpointReachable(id enode.ID) bool {
-	var node *enode.Node
+	var (
+		ip   net.IP
+		port int
+	)
+
 	srv.enodeMu.RLock()
-	for _, n := range srv.committee {
-		if id == n.ID() {
-			node = n
+	for _, node := range srv.committee {
+		if id == node.ID() {
+			ip = node.IP()
+			port = node.TCP()
 			break
 		}
 	}
 	srv.enodeMu.RUnlock()
-
-	if node == nil {
+	if ip == nil || port == 0 {
 		return false
 	}
-	srv.log.Info("verifying connectivity towards consensus endpoint", "ip", node.IP(), "port", node.TCP())
-	conn, err := srv.Dialer.Dial(context.Background(), node)
+
+	srv.log.Info("verifying connectivity towards consensus endpoint", "ip", ip, "port", port)
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip, port), defaultDialTimeout)
 	if err != nil {
-		srv.log.Warn("unable to reach peer consensus endpoint", "error", err, "peer", node.ID(), "ip", node.IP(), "port", node.TCP())
+		srv.log.Warn("unable to reach peer consensus endpoint", "error", err, "ip", ip, "port", port)
 		return false
 	}
 	_ = conn.Close()
@@ -980,7 +983,7 @@ func (srv *Server) postHandshakeChecks(peers map[enode.ID]*Peer, inboundCount in
 		return DiscPeerNotInCommittee
 	case srv.Net == Execution && srv.inCommittee(c.node.ID()) && !srv.inCommitteeSubset(c.node.ID()):
 		return DiscPeerOutsideTopology
-	case srv.Net == Consensus && c.is(inboundConn) && !srv.isConsensusEndpointReachable(c.node.ID()):
+	case srv.Net == Consensus && !srv.isConsensusEndpointReachable(c.node.ID()):
 		return DiscACNPeerNotReachable
 	default:
 		return nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -29,6 +29,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/common/mclock"
 	"github.com/autonity/autonity/crypto"
@@ -466,6 +468,30 @@ func (srv *Server) inCommittee(id enode.ID) bool {
 		}
 	}
 	return false
+}
+
+func (srv *Server) isConsensusEndpointReachable(id enode.ID) bool {
+	var node *enode.Node
+	srv.enodeMu.RLock()
+	for _, n := range srv.committee {
+		if id == n.ID() {
+			node = n
+			break
+		}
+	}
+	srv.enodeMu.RUnlock()
+
+	if node == nil {
+		return false
+	}
+	srv.log.Info("verifying connectivity towards consensus endpoint", "ip", node.IP(), "port", node.TCP())
+	conn, err := srv.Dialer.Dial(context.Background(), node)
+	if err != nil {
+		srv.log.Warn("unable to reach peer consensus endpoint", "error", err, "peer", node.ID(), "ip", node.IP(), "port", node.TCP())
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 func (srv *Server) SetCurrentBlockNumber(num uint64) {
@@ -954,6 +980,8 @@ func (srv *Server) postHandshakeChecks(peers map[enode.ID]*Peer, inboundCount in
 		return DiscPeerNotInCommittee
 	case srv.Net == Execution && srv.inCommittee(c.node.ID()) && !srv.inCommitteeSubset(c.node.ID()):
 		return DiscPeerOutsideTopology
+	case srv.Net == Consensus && !srv.isConsensusEndpointReachable(c.node.ID()):
+		return DiscACNPeerNotReachable
 	default:
 		return nil
 	}

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -170,6 +170,71 @@ func TestServerDial(t *testing.T) {
 	}
 }
 
+func TestIsConsensusEndpointReachable(t *testing.T) {
+	// --- Success Case: Node is in committee and a listener is accepting connections --- //
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start dummy listener: %v", err)
+	}
+	defer listener.Close()
+
+	acceptedCh := make(chan struct{})
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			_ = conn.Close()
+		}
+		close(acceptedCh)
+	}()
+
+	tcpAddr := listener.Addr().(*net.TCPAddr)
+
+	remoteKey := newkey().PublicKey
+	testNode := enode.NewV4(&remoteKey, tcpAddr.IP, tcpAddr.Port, 0)
+
+	srv := startTestServer(t, &remoteKey, func(p *Peer) {})
+	srv.Config.Dialer = tcpDialer{&net.Dialer{Timeout: 2 * time.Second}}
+
+	defer srv.Stop()
+
+	srv.enodeMu.Lock()
+	srv.committee = []*enode.Node{testNode}
+	srv.enodeMu.Unlock()
+
+	if !srv.isConsensusEndpointReachable(testNode.ID()) {
+		t.Error("expected isConsensusEndpointReachable to succeed, but it failed")
+	}
+
+	select {
+	case <-acceptedCh:
+	case <-time.After(2 * time.Second):
+		t.Error("dummy listener did not accept connection in time")
+	}
+
+	// --- Failure Case 1: Node not in committee --- //
+
+	// Create a node with a different ID.
+	fakeKey := newkey().PublicKey
+	fakeID := enode.PubkeyToIDV4(&fakeKey)
+	if srv.isConsensusEndpointReachable(fakeID) {
+		t.Error("expected isConsensusEndpointReachable to fail for a node not in committee, but it succeeded")
+	}
+
+	// --- Failure Case 2: Node in committee but no listener on its port --- //
+
+	remoteKey = newkey().PublicKey
+	// Choose a port where nothing is listening (port 1 is usually unused).
+	noListenerNode := enode.NewV4(&remoteKey, net.ParseIP("127.0.0.1"), 1, 0)
+	srv.enodeMu.Lock()
+	srv.committee = append(srv.committee, noListenerNode)
+	srv.enodeMu.Unlock()
+
+	if srv.isConsensusEndpointReachable(noListenerNode.ID()) {
+		t.Error("expected isConsensusEndpointReachable to fail due to connection failure, but it succeeded")
+	}
+}
+
 // This test checks that RemovePeer disconnects the peer if it is connected.
 func TestServerRemovePeerDisconnect(t *testing.T) {
 	srv1 := &Server{Config: Config{


### PR DESCRIPTION
During piccadilly network testing it was observed that some of the acn peers didn't open their consensus port correctly. due to which the peer count on consensus not was not consistent across cluster. Find more detailed description [here](https://github.com/clearmatics/web-priv-team-platform/issues/529).

This change would eliminate scenarios like this from occurring and the validators who don't have consensus port open will not be able to connect at all to any of the peers