### PR TITLE
Disable Docker E2E Tests Part 6

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -441,30 +441,30 @@ jobs:
       - name: Run docker e2e tests
         run: cd docker_e2e_test && make install-prerequisites-linux && make docker-e2e-tests START=17 END=22
 
-  docker-e2e-tests-part6:
-    needs: prepare-cache
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-        id: go
-
-      - name: Install pkg-config
-        run: go install github.com/influxdata/pkg-config@latest
-
-      - uses: actions/checkout@v3
-
-      - name: Go cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.GO_CACHE }}
-            ${{ env.GO_MODULES_CACHE }}
-          key: ${{ runner.os }}-gocache-${{ env.GO_VERSION }}${{ hashFiles('go.mod', 'go.sum') }}
-
-      - name: Build
-        run: make all
-
-      - name: Run docker e2e tests
-        run: cd docker_e2e_test && make install-prerequisites-linux && make docker-e2e-tests START=22 END=26
+#  docker-e2e-tests-part6:
+#    needs: prepare-cache
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/setup-go@v4
+#        with:
+#          go-version: ${{ env.GO_VERSION }}
+#        id: go
+#
+#      - name: Install pkg-config
+#        run: go install github.com/influxdata/pkg-config@latest
+#
+#      - uses: actions/checkout@v3
+#
+#      - name: Go cache
+#        uses: actions/cache@v4
+#        with:
+#          path: |
+#            ${{ env.GO_CACHE }}
+#            ${{ env.GO_MODULES_CACHE }}
+#          key: ${{ runner.os }}-gocache-${{ env.GO_VERSION }}${{ hashFiles('go.mod', 'go.sum') }}
+#
+#      - name: Build
+#        run: make all
+#
+#      - name: Run docker e2e tests
+#        run: cd docker_e2e_test && make install-prerequisites-linux && make docker-e2e-tests START=22 END=26


### PR DESCRIPTION
Docker E2E test part 6 is unreliable and does not pass consistently. Currently it is hindering our ability to easily view whether an open PR has running tests, as it is currently failing in every branch. 

We need to do a further investigation into why this test is failing, however in the meantime we need to maintain the usefulness of our code checks.

For now, I am opening this PR to disable the tests on via Github workflows.