### PR TITLE
Network clustering r3

### DIFF
--- a/consensus/tendermint/accountability/fault_detector.go
+++ b/consensus/tendermint/accountability/fault_detector.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"github.com/autonity/autonity/consensus/tendermint/core/constants"
 	"math"
 	"math/big"
 	"sort"
@@ -73,9 +72,10 @@ var (
 // read state db on each new height to get the latest challenges from autonity contract's view,
 // and to prove its innocent if there were any challenges on the suspicious node.
 type FaultDetector struct {
-	innocenceProofBuff *InnocenceProofBuffer
-	protocolContracts  *autonity.ProtocolContracts
-	rateLimiter        *AccusationRateLimiter
+	innocenceProofBuff    *InnocenceProofBuffer
+	protocolContracts     *autonity.ProtocolContracts
+	accusationRateLimiter *AccusationRateLimiter
+	askSyncRateLimiter    *AskSyncRateLimiter
 
 	wg               sync.WaitGroup
 	tendermintMsgSub *event.TypeMuxSubscription
@@ -86,6 +86,7 @@ type FaultDetector struct {
 
 	eventReporterCh chan *autonity.AccountabilityEvent
 	stopRetry       chan struct{}
+
 	// chain event subscriber for rule engine.
 	ruleEngineBlockCh  chan core.ChainEvent
 	ruleEngineBlockSub event.Subscription
@@ -133,7 +134,8 @@ func NewFaultDetector(
 	fd := &FaultDetector{
 		innocenceProofBuff:    NewInnocenceProofBuffer(),
 		protocolContracts:     protocolContracts,
-		rateLimiter:           NewAccusationRateLimiter(),
+		accusationRateLimiter: NewAccusationRateLimiter(),
+		askSyncRateLimiter:    NewAskSyncRateLimiter(),
 		txPool:                txPool,
 		ethBackend:            ethBackend,
 		txOpts:                txOpts,
@@ -239,7 +241,6 @@ tendermintMsgLoop:
 			case events.LostSyncEvent:
 				// process liveness fault from msg store context to release the consensus core locking in large scale network
 				// in which the processing of huge num of AskSyncs would lock the core for a long period.
-				// todo: handle the DoS vectors for this msg.
 				err := fd.handleLostSyncEvent(e.Payload, e.Sender)
 				if err != nil {
 					fd.logger.Error("Accountability: lost sync recovery", "error", err)
@@ -258,12 +259,13 @@ tendermintMsgLoop:
 
 			// on every 60 blocks, reset Peer Justified Accusations and height accusations counters.
 			if e.Block.NumberU64()%msgGCInterval == 0 {
-				fd.rateLimiter.resetHeightRateLimiter()
-				fd.rateLimiter.resetPeerJustifiedAccusations()
+				fd.askSyncRateLimiter.resetRateLimiter()
+				fd.accusationRateLimiter.resetHeightRateLimiter()
+				fd.accusationRateLimiter.resetPeerJustifiedAccusations()
 			}
 		case <-ticker.C:
 			// on each 1 seconds, reset the rate limiter counters.
-			fd.rateLimiter.resetRateLimiter()
+			fd.accusationRateLimiter.resetRateLimiter()
 		case err, ok := <-fd.chainEventSub.Err():
 			if ok {
 				// why crit? what can happen here?
@@ -273,238 +275,6 @@ tendermintMsgLoop:
 		}
 	}
 	close(fd.misbehaviourProofCh)
-}
-
-func (fd *FaultDetector) sendMissingProposals(lostSync *message.LostSyncMsg, sender common.Address) {
-	var missingProposals []*message.Propose
-
-	for _, roundView := range lostSync.RoundsViews {
-		// get missing proposals.
-		if roundView.Proposal == nilValue {
-			proposals := fd.msgStore.GetProposals(lostSync.Height, func(m *message.Propose) bool {
-				return uint64(m.R()) == roundView.Round
-			})
-			if len(proposals) > 0 {
-				missingProposals = append(missingProposals, proposals...)
-			}
-		}
-	}
-
-	if fd.broadcaster == nil {
-		fd.logger.Warn("p2p protocol handler is not ready yet")
-		return
-	}
-
-	peer, ok := fd.broadcaster.FindPeer(sender)
-	if !ok {
-		fd.logger.Debug("no peer connection from sender", "peer", sender)
-		return
-	}
-
-	for _, m := range missingProposals {
-		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
-	}
-	return
-}
-
-func (fd *FaultDetector) sendMissingPrevotes(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg, sender common.Address) error {
-	var missingPrevotes []*message.Prevote
-	for _, roundView := range lostSync.RoundsViews {
-		// get missing prevotes of the round, they could have different value and different signers.
-		presentedPrevoteVal := make(map[common.Hash]struct{})
-		for i, value := range roundView.Prevotes {
-
-			if _, ok := presentedPrevoteVal[value]; ok {
-				return errInvalidLostSyncMsg
-			} else {
-				presentedPrevoteVal[value] = struct{}{}
-			}
-
-			presentedSigners := roundView.PrevotesSigners[i]
-			if presentedSigners == nil {
-				return errInvalidLostSyncMsg
-			}
-
-			// select prevotes of the same round with same value but with different presentedSigners
-			prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
-				if uint64(m.R()) == roundView.Round && m.Value() == value {
-					// only with signers which is not in the presentedSigners
-					for _, idx := range m.Signers().FlattenUniq() {
-						if presentedSigners.Bit(idx) == 0 {
-							return true
-						}
-					}
-				}
-				return false
-			})
-
-			if len(prevotes) > 0 {
-				missingPrevotes = append(missingPrevotes, prevotes...)
-			}
-		}
-		// get prevotes of not presented values.
-		prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
-			if uint64(m.R()) == roundView.Round {
-				if _, ok := presentedPrevoteVal[m.Value()]; !ok {
-					return true
-				}
-			}
-			return false
-		})
-		if len(prevotes) > 0 {
-			missingPrevotes = append(missingPrevotes, prevotes...)
-		}
-	}
-
-	// select prevotes of not presented rounds.
-	prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
-		if _, ok := presentedRounds[uint64(m.R())]; !ok {
-			return true
-		}
-		return false
-	})
-
-	if len(prevotes) > 0 {
-		missingPrevotes = append(missingPrevotes, prevotes...)
-	}
-
-	if fd.broadcaster == nil {
-		fd.logger.Warn("p2p protocol handler is not ready yet")
-		return nil
-	}
-
-	peer, ok := fd.broadcaster.FindPeer(sender)
-	if !ok {
-		fd.logger.Debug("no peer connection for sender", "peer", sender)
-		return nil
-	}
-
-	for _, m := range missingPrevotes {
-		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
-	}
-	return nil
-}
-
-func (fd *FaultDetector) sendMissingPrecommits(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg, sender common.Address) error {
-	var missingPrecommits []*message.Precommit
-
-	for _, roundView := range lostSync.RoundsViews {
-		// get missing precommits.
-		presentedPrecommitVal := make(map[common.Hash]struct{})
-		for i, value := range roundView.Precommits {
-
-			if _, ok := presentedPrecommitVal[value]; ok {
-				return errInvalidLostSyncMsg
-			} else {
-				presentedPrecommitVal[value] = struct{}{}
-			}
-
-			presentedSigners := roundView.PrecommitsSigners[i]
-			if presentedSigners == nil {
-				return errInvalidLostSyncMsg
-			}
-
-			// select precommits of the same round with same value but with different presentedSigners
-			precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
-				if uint64(m.R()) == roundView.Round && m.Value() == value {
-					// only with signers which is not in the presentedSigners
-					for _, idx := range m.Signers().FlattenUniq() {
-						if presentedSigners.Bit(idx) == 0 {
-							return true
-						}
-					}
-				}
-				return false
-			})
-
-			if len(precommits) > 0 {
-				missingPrecommits = append(missingPrecommits, precommits...)
-			}
-		}
-		// get precommits of not presented values.
-		precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
-			if uint64(m.R()) == roundView.Round {
-				if _, ok := presentedPrecommitVal[m.Value()]; !ok {
-					return true
-				}
-			}
-			return false
-		})
-		if len(precommits) > 0 {
-			missingPrecommits = append(missingPrecommits, precommits...)
-		}
-	}
-
-	// select precommits of not presented rounds.
-	precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
-		if _, ok := presentedRounds[uint64(m.R())]; !ok {
-			return true
-		}
-		return false
-	})
-
-	if len(precommits) > 0 {
-		missingPrecommits = append(missingPrecommits, precommits...)
-	}
-
-	if fd.broadcaster == nil {
-		fd.logger.Warn("p2p protocol handler is not ready yet")
-		return nil
-	}
-
-	peer, ok := fd.broadcaster.FindPeer(sender)
-	if !ok {
-		fd.logger.Debug("no peer connection for sender", "peer", sender)
-		return nil
-	}
-
-	for _, m := range missingPrecommits {
-		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
-	}
-
-	return nil
-}
-
-func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Address) error {
-	var lostSync message.LostSyncMsg
-	err := rlp.DecodeBytes(payload, &lostSync)
-	if err != nil {
-		return err
-	}
-
-	// sanity checks: no duplicated rounds, and msg set bound checks.
-	presentedRounds := make(map[uint64]struct{})
-	for _, v := range lostSync.RoundsViews {
-		if v.Round > constants.MaxRound {
-			return errInvalidLostSyncMsg
-		}
-		if _, ok := presentedRounds[v.Round]; ok {
-			return errInvalidLostSyncMsg
-		} else {
-			presentedRounds[v.Round] = struct{}{}
-		}
-		if len(v.Prevotes) != len(v.PrevotesSigners) || len(v.Precommits) != len(v.PrecommitsSigners) {
-			return errInvalidLostSyncMsg
-		}
-	}
-
-	// prioritized the missing precomits as it could trigger the remote peer step into next round or to commit a value.
-	err = fd.sendMissingPrecommits(presentedRounds, &lostSync, sender)
-	if err != nil {
-		fd.logger.Error("Going to suspend peer connection", "err", err, "peer", sender)
-		return err
-	}
-
-	// otherwise, we send missing prevotes to get remote peer change its voting step.
-	err = fd.sendMissingPrevotes(presentedRounds, &lostSync, sender)
-	if err != nil {
-		fd.logger.Error("Going to suspend per connection", "err", err, "peer", sender)
-		return err
-	}
-
-	// at the end, we send the most heavy msg, the missing proposals.
-	fd.sendMissingProposals(&lostSync, sender)
-	return nil
 }
 
 // check to GC msg store for those msgs out of buffering window on every 60 blocks.

--- a/consensus/tendermint/accountability/fault_detector.go
+++ b/consensus/tendermint/accountability/fault_detector.go
@@ -239,6 +239,7 @@ tendermintMsgLoop:
 			case events.LostSyncEvent:
 				// process liveness fault from msg store context to release the consensus core locking in large scale network
 				// in which the processing of huge num of AskSyncs would lock the core for a long period.
+				// todo: handle the DoS vectors for this msg.
 				err := fd.handleLostSyncEvent(e.Payload, e.Sender)
 				if err != nil {
 					fd.logger.Error("Accountability: lost sync recovery", "error", err)
@@ -274,35 +275,8 @@ tendermintMsgLoop:
 	close(fd.misbehaviourProofCh)
 }
 
-// todo: refine this function.
-func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Address) error {
-	var lostSync message.LostSyncMsg
-	err := rlp.DecodeBytes(payload, &lostSync)
-	if err != nil {
-		return err
-	}
-
-	// sanity checks, no duplicated rounds, and msg set bound checks.
-	presentedRounds := make(map[uint64]struct{})
-	for _, v := range lostSync.RoundsViews {
-		if v.Round > constants.MaxRound {
-			return errInvalidLostSyncMsg
-		}
-		if _, ok := presentedRounds[v.Round]; ok {
-			return errInvalidLostSyncMsg
-		} else {
-			presentedRounds[v.Round] = struct{}{}
-		}
-		if len(v.Prevotes) != len(v.PrevotesSigners) || len(v.Precommits) != len(v.PrecommitsSigners) {
-			return errInvalidLostSyncMsg
-		}
-	}
-
-	// todo: consider a rate limit for the sender from DoS, double check if the msg is being relaying.
-
+func (fd *FaultDetector) sendMissingProposals(lostSync *message.LostSyncMsg, sender common.Address) {
 	var missingProposals []*message.Propose
-	var missingPrevotes []*message.Prevote
-	var missingPrecommits []*message.Precommit
 
 	for _, roundView := range lostSync.RoundsViews {
 		// get missing proposals.
@@ -314,7 +288,28 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 				missingProposals = append(missingProposals, proposals...)
 			}
 		}
+	}
 
+	if fd.broadcaster == nil {
+		fd.logger.Warn("p2p protocol handler is not ready yet")
+		return
+	}
+
+	peer, ok := fd.broadcaster.FindPeer(sender)
+	if !ok {
+		fd.logger.Debug("no peer connection from sender", "peer", sender)
+		return
+	}
+
+	for _, m := range missingProposals {
+		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+	}
+	return
+}
+
+func (fd *FaultDetector) sendMissingPrevotes(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg, sender common.Address) error {
+	var missingPrevotes []*message.Prevote
+	for _, roundView := range lostSync.RoundsViews {
 		// get missing prevotes of the round, they could have different value and different signers.
 		presentedPrevoteVal := make(map[common.Hash]struct{})
 		for i, value := range roundView.Prevotes {
@@ -359,9 +354,41 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 		if len(prevotes) > 0 {
 			missingPrevotes = append(missingPrevotes, prevotes...)
 		}
+	}
 
-		// ----------------------
+	// select prevotes of not presented rounds.
+	prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+		if _, ok := presentedRounds[uint64(m.R())]; !ok {
+			return true
+		}
+		return false
+	})
 
+	if len(prevotes) > 0 {
+		missingPrevotes = append(missingPrevotes, prevotes...)
+	}
+
+	if fd.broadcaster == nil {
+		fd.logger.Warn("p2p protocol handler is not ready yet")
+		return nil
+	}
+
+	peer, ok := fd.broadcaster.FindPeer(sender)
+	if !ok {
+		fd.logger.Debug("no peer connection for sender", "peer", sender)
+		return nil
+	}
+
+	for _, m := range missingPrevotes {
+		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+	}
+	return nil
+}
+
+func (fd *FaultDetector) sendMissingPrecommits(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg, sender common.Address) error {
+	var missingPrecommits []*message.Precommit
+
+	for _, roundView := range lostSync.RoundsViews {
 		// get missing precommits.
 		presentedPrecommitVal := make(map[common.Hash]struct{})
 		for i, value := range roundView.Precommits {
@@ -377,7 +404,7 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 				return errInvalidLostSyncMsg
 			}
 
-			// select precommit of the same round with same value but with different presentedSigners
+			// select precommits of the same round with same value but with different presentedSigners
 			precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
 				if uint64(m.R()) == roundView.Round && m.Value() == value {
 					// only with signers which is not in the presentedSigners
@@ -408,27 +435,16 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 		}
 	}
 
-	// select prevotes of not presented rounds.
-	prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
-		if _, ok := presentedRounds[uint64(m.R())]; !ok {
-			return true
-		}
-		return false
-	})
-	if len(prevotes) > 0 {
-		missingPrevotes = append(missingPrevotes, prevotes...)
-	}
-
 	// select precommits of not presented rounds.
-	precommit := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
+	precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
 		if _, ok := presentedRounds[uint64(m.R())]; !ok {
 			return true
 		}
 		return false
 	})
 
-	if len(precommit) > 0 {
-		missingPrecommits = append(missingPrecommits, precommit...)
+	if len(precommits) > 0 {
+		missingPrecommits = append(missingPrecommits, precommits...)
 	}
 
 	if fd.broadcaster == nil {
@@ -438,22 +454,56 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 
 	peer, ok := fd.broadcaster.FindPeer(sender)
 	if !ok {
-		fd.logger.Debug("no peer connection for off chain innocence proof event")
+		fd.logger.Debug("no peer connection for sender", "peer", sender)
 		return nil
-	}
-
-	for _, m := range missingProposals {
-		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
-	}
-
-	for _, m := range missingProposals {
-		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
 	}
 
 	for _, m := range missingPrecommits {
 		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
 	}
 
+	return nil
+}
+
+func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Address) error {
+	var lostSync message.LostSyncMsg
+	err := rlp.DecodeBytes(payload, &lostSync)
+	if err != nil {
+		return err
+	}
+
+	// sanity checks: no duplicated rounds, and msg set bound checks.
+	presentedRounds := make(map[uint64]struct{})
+	for _, v := range lostSync.RoundsViews {
+		if v.Round > constants.MaxRound {
+			return errInvalidLostSyncMsg
+		}
+		if _, ok := presentedRounds[v.Round]; ok {
+			return errInvalidLostSyncMsg
+		} else {
+			presentedRounds[v.Round] = struct{}{}
+		}
+		if len(v.Prevotes) != len(v.PrevotesSigners) || len(v.Precommits) != len(v.PrecommitsSigners) {
+			return errInvalidLostSyncMsg
+		}
+	}
+
+	// prioritized the missing precomits as it could trigger the remote peer step into next round or to commit a value.
+	err = fd.sendMissingPrecommits(presentedRounds, &lostSync, sender)
+	if err != nil {
+		fd.logger.Error("Going to suspend peer connection", "err", err, "peer", sender)
+		return err
+	}
+
+	// otherwise, we send missing prevotes to get remote peer change its voting step.
+	err = fd.sendMissingPrevotes(presentedRounds, &lostSync, sender)
+	if err != nil {
+		fd.logger.Error("Going to suspend per connection", "err", err, "peer", sender)
+		return err
+	}
+
+	// at the end, we send the most heavy msg, the missing proposals.
+	fd.sendMissingProposals(&lostSync, sender)
 	return nil
 }
 

--- a/consensus/tendermint/accountability/fault_detector.go
+++ b/consensus/tendermint/accountability/fault_detector.go
@@ -233,6 +233,19 @@ tendermintMsgLoop:
 					}
 					continue tendermintMsgLoop
 				}
+			case events.LostSyncEvent:
+				// process liveness fault from msg store context to release the consensus core locking in large scale network
+				// in which the processing of huge num of AskSyncs would lock the core for a long period.
+				err := fd.handleLostSyncEvent(e.Payload, e.Sender)
+				if err != nil {
+					fd.logger.Error("Accountability: lost sync recovery", "error", err)
+					// the errors return from handler could freeze the peer connection for 30 seconds by according to dev p2p protocol.
+					select {
+					case e.ErrCh <- err:
+					default: // do nothing
+					}
+					continue tendermintMsgLoop
+				}
 			}
 		case e, ok := <-fd.chainEventCh:
 			if !ok {
@@ -256,6 +269,22 @@ tendermintMsgLoop:
 		}
 	}
 	close(fd.misbehaviourProofCh)
+}
+
+func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Address) error {
+	var lostSync message.LostSyncMsg
+	err := rlp.DecodeBytes(payload, &lostSync)
+	if err != nil {
+		return err
+	}
+
+	// todo: consider a rate limit for the sender from DoS, double check if the msg is being relaying.
+
+	// todo: query missing msgs from msg store, with height, round, step and signers.
+
+	// todo: send the msg back to the sender.
+
+	return nil
 }
 
 // check to GC msg store for those msgs out of buffering window on every 60 blocks.

--- a/consensus/tendermint/accountability/fault_detector.go
+++ b/consensus/tendermint/accountability/fault_detector.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"github.com/autonity/autonity/consensus/tendermint/core/constants"
 	"math"
 	"math/big"
 	"sort"
@@ -61,6 +62,8 @@ var (
 	errNoEvidenceForPVN = errors.New("no proof of innocence found for rule PVN")
 	errNoEvidenceForPVO = errors.New("no proof of innocence found for rule PVO")
 	errNoEvidenceForC1  = errors.New("no proof of innocence found for rule C1")
+
+	errInvalidLostSyncMsg = errors.New("invalid ask sync message")
 
 	nilValue = common.Hash{}
 )
@@ -271,6 +274,7 @@ tendermintMsgLoop:
 	close(fd.misbehaviourProofCh)
 }
 
+// todo: refine this function.
 func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Address) error {
 	var lostSync message.LostSyncMsg
 	err := rlp.DecodeBytes(payload, &lostSync)
@@ -278,11 +282,177 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 		return err
 	}
 
+	// sanity checks, no duplicated rounds, and msg set bound checks.
+	presentedRounds := make(map[uint64]struct{})
+	for _, v := range lostSync.RoundsViews {
+		if v.Round > constants.MaxRound {
+			return errInvalidLostSyncMsg
+		}
+		if _, ok := presentedRounds[v.Round]; ok {
+			return errInvalidLostSyncMsg
+		} else {
+			presentedRounds[v.Round] = struct{}{}
+		}
+		if len(v.Prevotes) != len(v.PrevotesSigners) || len(v.Precommits) != len(v.PrecommitsSigners) {
+			return errInvalidLostSyncMsg
+		}
+	}
+
 	// todo: consider a rate limit for the sender from DoS, double check if the msg is being relaying.
 
-	// todo: query missing msgs from msg store, with height, round, step and signers.
+	var missingProposals []*message.Propose
+	var missingPrevotes []*message.Prevote
+	var missingPrecommits []*message.Precommit
 
-	// todo: send the msg back to the sender.
+	for _, roundView := range lostSync.RoundsViews {
+		// get missing proposals.
+		if roundView.Proposal == nilValue {
+			proposals := fd.msgStore.GetProposals(lostSync.Height, func(m *message.Propose) bool {
+				return uint64(m.R()) == roundView.Round
+			})
+			if len(proposals) > 0 {
+				missingProposals = append(missingProposals, proposals...)
+			}
+		}
+
+		// get missing prevotes of the round, they could have different value and different signers.
+		presentedPrevoteVal := make(map[common.Hash]struct{})
+		for i, value := range roundView.Prevotes {
+
+			if _, ok := presentedPrevoteVal[value]; ok {
+				return errInvalidLostSyncMsg
+			} else {
+				presentedPrevoteVal[value] = struct{}{}
+			}
+
+			presentedSigners := roundView.PrevotesSigners[i]
+			if presentedSigners == nil {
+				return errInvalidLostSyncMsg
+			}
+
+			// select prevotes of the same round with same value but with different presentedSigners
+			prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+				if uint64(m.R()) == roundView.Round && m.Value() == value {
+					// only with signers which is not in the presentedSigners
+					for _, idx := range m.Signers().FlattenUniq() {
+						if presentedSigners.Bit(idx) == 0 {
+							return true
+						}
+					}
+				}
+				return false
+			})
+
+			if len(prevotes) > 0 {
+				missingPrevotes = append(missingPrevotes, prevotes...)
+			}
+		}
+		// get prevotes of not presented values.
+		prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+			if uint64(m.R()) == roundView.Round {
+				if _, ok := presentedPrevoteVal[m.Value()]; !ok {
+					return true
+				}
+			}
+			return false
+		})
+		if len(prevotes) > 0 {
+			missingPrevotes = append(missingPrevotes, prevotes...)
+		}
+
+		// ----------------------
+
+		// get missing precommits.
+		presentedPrecommitVal := make(map[common.Hash]struct{})
+		for i, value := range roundView.Precommits {
+
+			if _, ok := presentedPrecommitVal[value]; ok {
+				return errInvalidLostSyncMsg
+			} else {
+				presentedPrecommitVal[value] = struct{}{}
+			}
+
+			presentedSigners := roundView.PrecommitsSigners[i]
+			if presentedSigners == nil {
+				return errInvalidLostSyncMsg
+			}
+
+			// select precommit of the same round with same value but with different presentedSigners
+			precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
+				if uint64(m.R()) == roundView.Round && m.Value() == value {
+					// only with signers which is not in the presentedSigners
+					for _, idx := range m.Signers().FlattenUniq() {
+						if presentedSigners.Bit(idx) == 0 {
+							return true
+						}
+					}
+				}
+				return false
+			})
+
+			if len(precommits) > 0 {
+				missingPrecommits = append(missingPrecommits, precommits...)
+			}
+		}
+		// get precommits of not presented values.
+		precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
+			if uint64(m.R()) == roundView.Round {
+				if _, ok := presentedPrecommitVal[m.Value()]; !ok {
+					return true
+				}
+			}
+			return false
+		})
+		if len(precommits) > 0 {
+			missingPrecommits = append(missingPrecommits, precommits...)
+		}
+	}
+
+	// select prevotes of not presented rounds.
+	prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+		if _, ok := presentedRounds[uint64(m.R())]; !ok {
+			return true
+		}
+		return false
+	})
+	if len(prevotes) > 0 {
+		missingPrevotes = append(missingPrevotes, prevotes...)
+	}
+
+	// select precommits of not presented rounds.
+	precommit := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
+		if _, ok := presentedRounds[uint64(m.R())]; !ok {
+			return true
+		}
+		return false
+	})
+
+	if len(precommit) > 0 {
+		missingPrecommits = append(missingPrecommits, precommit...)
+	}
+
+	if fd.broadcaster == nil {
+		fd.logger.Warn("p2p protocol handler is not ready yet")
+		return nil
+	}
+
+	peer, ok := fd.broadcaster.FindPeer(sender)
+	if !ok {
+		fd.logger.Debug("no peer connection for off chain innocence proof event")
+		return nil
+	}
+
+	for _, m := range missingProposals {
+		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+	}
+
+	for _, m := range missingProposals {
+		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+	}
+
+	for _, m := range missingPrecommits {
+		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+	}
 
 	return nil
 }

--- a/consensus/tendermint/accountability/innocence_proof_handler.go
+++ b/consensus/tendermint/accountability/innocence_proof_handler.go
@@ -157,7 +157,7 @@ func (i *InnocenceProofBuffer) getInnocenceProofFromCache(challengeHash common.H
 // NOTE: sender is the p2p sender of the offchain accountability message
 func (fd *FaultDetector) handleOffChainAccountabilityEvent(payload []byte, sender common.Address) error {
 	// drop peer if the accusation exceed the rate limit during the last 1 seconds.
-	err := fd.rateLimiter.validAccusationRate(sender)
+	err := fd.accusationRateLimiter.validAccusationRate(sender)
 	if err != nil {
 		fd.logger.Error("accountability abuse detected!", "err", err)
 		return err
@@ -165,7 +165,7 @@ func (fd *FaultDetector) handleOffChainAccountabilityEvent(payload []byte, sende
 
 	// drop peer if it sent duplicated accusation event.
 	msgHash := crypto.Hash(payload)
-	err = fd.rateLimiter.checkPeerDuplicatedAccusation(sender, msgHash)
+	err = fd.accusationRateLimiter.checkPeerDuplicatedAccusation(sender, msgHash)
 	if err != nil {
 		fd.logger.Error("duplicated accusation from peer", "err", err)
 		return err
@@ -199,7 +199,7 @@ func (fd *FaultDetector) handleOffChainAccountabilityEvent(payload []byte, sende
 	}
 
 	// drop peer if one send more than the number of accusations could be produced by rule engine over a height.
-	err = fd.rateLimiter.checkHeightAccusationRate(sender, msgHeight)
+	err = fd.accusationRateLimiter.checkHeightAccusationRate(sender, msgHeight)
 	if err != nil {
 		fd.logger.Info("over rated accusation over a height", "error", err)
 		return err

--- a/consensus/tendermint/accountability/lost_sync_handler.go
+++ b/consensus/tendermint/accountability/lost_sync_handler.go
@@ -14,8 +14,6 @@ import (
 // more over that, future round messages can be synced now and the handling of AskSync msg does not block the consensus
 // engine anymore.
 
-var askSyncInterval = 5 // 5s
-
 var errAskSyncOverRated = errors.New("ask sync over rated")
 
 type AskSyncRateLimiter struct {
@@ -40,7 +38,7 @@ func (r *AskSyncRateLimiter) overRated(asker common.Address) bool {
 	r.lastRequestTSs[asker] = now
 	timeDiff := now - lastTS
 
-	return timeDiff < int64(askSyncInterval)
+	return timeDiff < int64(constants.AskSyncInterval)
 }
 
 func (r *AskSyncRateLimiter) resetRateLimiter() {
@@ -150,7 +148,7 @@ func (fd *FaultDetector) missingProposals(presentedRounds map[uint64]struct{}, l
 		}
 	}
 
-	// collected those proposals of the asker's not presented rounds
+	// collected those proposals of the asker's unknown rounds
 	proposals := fd.msgStore.GetProposals(lostSync.Height, func(m *message.Propose) bool {
 		if _, ok := presentedRounds[uint64(m.R())]; !ok {
 			return true

--- a/consensus/tendermint/accountability/lost_sync_handler.go
+++ b/consensus/tendermint/accountability/lost_sync_handler.go
@@ -1,0 +1,289 @@
+package accountability
+
+import (
+	"errors"
+	"github.com/autonity/autonity/common"
+	"github.com/autonity/autonity/consensus/tendermint/core/constants"
+	"github.com/autonity/autonity/consensus/tendermint/core/message"
+	"github.com/autonity/autonity/rlp"
+	"time"
+)
+
+// lost sync handler, process the ask sync msg from a lost liveness node. As the msg store in the AFD module saves recent
+// 256 blocks consensus messages, thus it provides extensive msg views for those chain head synced or un-synced nodes,
+// more over that, future round messages can be synced now and the handling of AskSync msg does not block the consensus
+// engine anymore.
+
+var askSyncInterval = 20 // 20s
+
+var errAskSyncOverRated = errors.New("ask sync over rated")
+
+type AskSyncRateLimiter struct {
+	lastRequestTSs map[common.Address]int64
+}
+
+func NewAskSyncRateLimiter() *AskSyncRateLimiter {
+	return &AskSyncRateLimiter{
+		lastRequestTSs: make(map[common.Address]int64),
+	}
+}
+
+func (r *AskSyncRateLimiter) overRated(asker common.Address) bool {
+	now := time.Now().Unix()
+
+	lastTS, exists := r.lastRequestTSs[asker]
+	if !exists {
+		r.lastRequestTSs[asker] = now
+		return false
+	}
+
+	timeDiff := now - lastTS
+
+	return timeDiff < int64(askSyncInterval)
+}
+
+func (r *AskSyncRateLimiter) resetRateLimiter() {
+	for k := range r.lastRequestTSs {
+		delete(r.lastRequestTSs, k)
+	}
+}
+
+func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Address) error {
+
+	if fd.askSyncRateLimiter.overRated(sender) {
+		return errAskSyncOverRated
+	}
+
+	var lostSync message.LostSyncMsg
+	err := rlp.DecodeBytes(payload, &lostSync)
+	if err != nil {
+		return err
+	}
+
+	// sanity checks: no duplicated rounds, and msg set bound checks.
+	presentedRounds := make(map[uint64]struct{})
+	for _, v := range lostSync.RoundsViews {
+		if v.Round > constants.MaxRound {
+			return errInvalidLostSyncMsg
+		}
+		if _, ok := presentedRounds[v.Round]; ok {
+			return errInvalidLostSyncMsg
+		} else {
+			presentedRounds[v.Round] = struct{}{}
+		}
+		if len(v.Prevotes) != len(v.PrevotesSigners) || len(v.Precommits) != len(v.PrecommitsSigners) {
+			return errInvalidLostSyncMsg
+		}
+	}
+
+	// prioritized the missing precomits as it could trigger the remote peer step into next round or to commit a value.
+	err = fd.sendMissingPrecommits(presentedRounds, &lostSync, sender)
+	if err != nil {
+		fd.logger.Error("Going to suspend peer connection", "err", err, "peer", sender)
+		return err
+	}
+
+	// otherwise, we send missing prevotes to get remote peer change its voting step.
+	err = fd.sendMissingPrevotes(presentedRounds, &lostSync, sender)
+	if err != nil {
+		fd.logger.Error("Going to suspend per connection", "err", err, "peer", sender)
+		return err
+	}
+
+	// at the end, we send the most heavy msg, the missing proposals.
+	fd.sendMissingProposals(&lostSync, sender)
+	return nil
+}
+
+func (fd *FaultDetector) sendMissingProposals(lostSync *message.LostSyncMsg, sender common.Address) {
+	var missingProposals []*message.Propose
+
+	for _, roundView := range lostSync.RoundsViews {
+		// get missing proposals.
+		if roundView.Proposal == nilValue {
+			proposals := fd.msgStore.GetProposals(lostSync.Height, func(m *message.Propose) bool {
+				return uint64(m.R()) == roundView.Round
+			})
+			if len(proposals) > 0 {
+				missingProposals = append(missingProposals, proposals...)
+			}
+		}
+	}
+
+	if fd.broadcaster == nil {
+		fd.logger.Warn("p2p protocol handler is not ready yet")
+		return
+	}
+
+	peer, ok := fd.broadcaster.FindPeer(sender)
+	if !ok {
+		fd.logger.Debug("no peer connection from sender", "peer", sender)
+		return
+	}
+
+	for _, m := range missingProposals {
+		fd.logger.Info("sending missing proposal to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "VR", m.ValidRound(), "from", fd.address, "to", sender)
+		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+	}
+	return
+}
+
+func (fd *FaultDetector) sendMissingPrevotes(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg, sender common.Address) error {
+	var missingPrevotes []*message.Prevote
+	for _, roundView := range lostSync.RoundsViews {
+		// get missing prevotes of the round, they could have different value and different signers.
+		presentedPrevoteVal := make(map[common.Hash]struct{})
+		for i, value := range roundView.Prevotes {
+
+			if _, ok := presentedPrevoteVal[value]; ok {
+				return errInvalidLostSyncMsg
+			} else {
+				presentedPrevoteVal[value] = struct{}{}
+			}
+
+			presentedSigners := roundView.PrevotesSigners[i]
+			if presentedSigners == nil {
+				return errInvalidLostSyncMsg
+			}
+
+			// select prevotes of the same round with same value but with different presentedSigners
+			prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+				if uint64(m.R()) == roundView.Round && m.Value() == value {
+					// only with signers which is not in the presentedSigners
+					for _, idx := range m.Signers().FlattenUniq() {
+						if presentedSigners.Bit(idx) == 0 {
+							return true
+						}
+					}
+				}
+				return false
+			})
+
+			if len(prevotes) > 0 {
+				missingPrevotes = append(missingPrevotes, prevotes...)
+			}
+		}
+		// get prevotes of not presented values.
+		prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+			if uint64(m.R()) == roundView.Round {
+				if _, ok := presentedPrevoteVal[m.Value()]; !ok {
+					return true
+				}
+			}
+			return false
+		})
+		if len(prevotes) > 0 {
+			missingPrevotes = append(missingPrevotes, prevotes...)
+		}
+	}
+
+	// select prevotes of not presented rounds.
+	prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+		if _, ok := presentedRounds[uint64(m.R())]; !ok {
+			return true
+		}
+		return false
+	})
+
+	if len(prevotes) > 0 {
+		missingPrevotes = append(missingPrevotes, prevotes...)
+	}
+
+	if fd.broadcaster == nil {
+		fd.logger.Warn("p2p protocol handler is not ready yet")
+		return nil
+	}
+
+	peer, ok := fd.broadcaster.FindPeer(sender)
+	if !ok {
+		fd.logger.Debug("no peer connection for sender", "peer", sender)
+		return nil
+	}
+
+	for _, m := range missingPrevotes {
+		fd.logger.Info("sending missing prevote to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
+		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+	}
+	return nil
+}
+
+func (fd *FaultDetector) sendMissingPrecommits(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg, sender common.Address) error {
+	var missingPrecommits []*message.Precommit
+
+	for _, roundView := range lostSync.RoundsViews {
+		// get missing precommits.
+		presentedPrecommitVal := make(map[common.Hash]struct{})
+		for i, value := range roundView.Precommits {
+
+			if _, ok := presentedPrecommitVal[value]; ok {
+				return errInvalidLostSyncMsg
+			} else {
+				presentedPrecommitVal[value] = struct{}{}
+			}
+
+			presentedSigners := roundView.PrecommitsSigners[i]
+			if presentedSigners == nil {
+				return errInvalidLostSyncMsg
+			}
+
+			// select precommits of the same round with same value but with different presentedSigners
+			precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
+				if uint64(m.R()) == roundView.Round && m.Value() == value {
+					// only with signers which is not in the presentedSigners
+					for _, idx := range m.Signers().FlattenUniq() {
+						if presentedSigners.Bit(idx) == 0 {
+							return true
+						}
+					}
+				}
+				return false
+			})
+
+			if len(precommits) > 0 {
+				missingPrecommits = append(missingPrecommits, precommits...)
+			}
+		}
+		// get precommits of not presented values.
+		precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
+			if uint64(m.R()) == roundView.Round {
+				if _, ok := presentedPrecommitVal[m.Value()]; !ok {
+					return true
+				}
+			}
+			return false
+		})
+		if len(precommits) > 0 {
+			missingPrecommits = append(missingPrecommits, precommits...)
+		}
+	}
+
+	// select precommits of not presented rounds.
+	precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
+		if _, ok := presentedRounds[uint64(m.R())]; !ok {
+			return true
+		}
+		return false
+	})
+
+	if len(precommits) > 0 {
+		missingPrecommits = append(missingPrecommits, precommits...)
+	}
+
+	if fd.broadcaster == nil {
+		fd.logger.Warn("p2p protocol handler is not ready yet")
+		return nil
+	}
+
+	peer, ok := fd.broadcaster.FindPeer(sender)
+	if !ok {
+		fd.logger.Debug("no peer connection for sender", "peer", sender)
+		return nil
+	}
+
+	for _, m := range missingPrecommits {
+		fd.logger.Info("sending missing precomit to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
+		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+	}
+
+	return nil
+}

--- a/consensus/tendermint/accountability/lost_sync_handler.go
+++ b/consensus/tendermint/accountability/lost_sync_handler.go
@@ -49,6 +49,8 @@ func (r *AskSyncRateLimiter) resetRateLimiter() {
 	}
 }
 
+// handleLostSyncEvent handles the ask sync request from a lost sync validator or from a rebooting validator.
+// Any error return from this function will drop the remote peer.
 func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Address) error {
 
 	if fd.askSyncRateLimiter.overRated(sender) {
@@ -81,13 +83,13 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 	}
 
 	proposals := fd.missingProposals(&lostSync)
-	preCommits, err := fd.missingPrecommits(presentedRounds, &lostSync)
+	preCommits, err := fd.missingVotes(presentedRounds, message.PrecommitCode, &lostSync)
 	if err != nil {
 		fd.logger.Error("Going to suspend peer connection", "err", err, "peer", sender)
 		return err
 	}
 
-	preVotes, err := fd.missingPrevotes(presentedRounds, &lostSync)
+	preVotes, err := fd.missingVotes(presentedRounds, message.PrevoteCode, &lostSync)
 	if err != nil {
 		fd.logger.Error("Going to suspend per connection", "err", err, "peer", sender)
 		return err
@@ -130,11 +132,13 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 	return nil
 }
 
+// missingProposals collects all the missing proposals of a consensus instance base on the asker's view.
 func (fd *FaultDetector) missingProposals(lostSync *message.LostSyncMsg) []*message.Propose {
 	var missingProposals []*message.Propose
 
 	for _, roundView := range lostSync.RoundsViews {
-		// get missing proposals.
+		// from the asker's round view, if it missed a proposal of that round, then we need to send
+		// any proposal of that round, otherwise we don't send it as the asker already prevoted for a value.
 		if roundView.Proposal == nilValue {
 			proposals := fd.msgStore.GetProposals(lostSync.Height, func(m *message.Propose) bool {
 				return uint64(m.R()) == roundView.Round
@@ -148,26 +152,36 @@ func (fd *FaultDetector) missingProposals(lostSync *message.LostSyncMsg) []*mess
 	return missingProposals
 }
 
-func (fd *FaultDetector) missingPrevotes(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg) ([]*message.Prevote, error) {
-	var missingPrevotes []*message.Prevote
+// missingVotes collects those missing prevotes, or precommits of the asker. They include those votes of missing signers, values and rounds.
+func (fd *FaultDetector) missingVotes(presentedRounds map[uint64]struct{}, step uint8, lostSync *message.LostSyncMsg) ([]message.Vote, error) {
+	var missingVotes []message.Vote
 	for _, roundView := range lostSync.RoundsViews {
-		// get missing prevotes of the round, they could have different value and different signers.
-		presentedPrevoteVal := make(map[common.Hash]struct{})
-		for i, value := range roundView.Prevotes {
+		// get missing votes of the round, they could have different value and different signers.
+		presentedValue := make(map[common.Hash]struct{})
 
-			if _, ok := presentedPrevoteVal[value]; ok {
+		// query for prevotes by default,
+		knownVotes := roundView.Prevotes
+		knownVotesSigners := roundView.PrevotesSigners
+		if message.PrecommitCode == step {
+			knownVotes = roundView.Precommits
+			knownVotesSigners = roundView.PrecommitsSigners
+		}
+
+		for i, value := range knownVotes {
+
+			if _, ok := presentedValue[value]; ok {
 				return nil, errInvalidLostSyncMsg
 			} else {
-				presentedPrevoteVal[value] = struct{}{}
+				presentedValue[value] = struct{}{}
 			}
 
-			presentedSigners := roundView.PrevotesSigners[i]
+			presentedSigners := knownVotesSigners[i]
 			if presentedSigners == nil {
 				return nil, errInvalidLostSyncMsg
 			}
 
-			// select prevotes of the same round with same value but with different presentedSigners
-			prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+			// select votes of the same round with same value but with different presentedSigners
+			votes := fd.msgStore.GetVotes(lostSync.Height, step, func(m message.Vote) bool {
 				if uint64(m.R()) == roundView.Round && m.Value() == value {
 					// only with signers which is not in the presentedSigners
 					for _, idx := range m.Signers().FlattenUniq() {
@@ -179,100 +193,35 @@ func (fd *FaultDetector) missingPrevotes(presentedRounds map[uint64]struct{}, lo
 				return false
 			})
 
-			if len(prevotes) > 0 {
-				missingPrevotes = append(missingPrevotes, prevotes...)
+			if len(votes) > 0 {
+				missingVotes = append(missingVotes, votes...)
 			}
 		}
-		// get prevotes of not presented values.
-		prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+		// get votes of not presented values.
+		votes := fd.msgStore.GetVotes(lostSync.Height, step, func(m message.Vote) bool {
 			if uint64(m.R()) == roundView.Round {
-				if _, ok := presentedPrevoteVal[m.Value()]; !ok {
+				if _, ok := presentedValue[m.Value()]; !ok {
 					return true
 				}
 			}
 			return false
 		})
-		if len(prevotes) > 0 {
-			missingPrevotes = append(missingPrevotes, prevotes...)
+		if len(votes) > 0 {
+			missingVotes = append(missingVotes, votes...)
 		}
 	}
 
-	// select prevotes of not presented rounds.
-	prevotes := fd.msgStore.GetPrevotes(lostSync.Height, func(m *message.Prevote) bool {
+	// select votes of not presented rounds.
+	votes := fd.msgStore.GetVotes(lostSync.Height, step, func(m message.Vote) bool {
 		if _, ok := presentedRounds[uint64(m.R())]; !ok {
 			return true
 		}
 		return false
 	})
 
-	if len(prevotes) > 0 {
-		missingPrevotes = append(missingPrevotes, prevotes...)
+	if len(votes) > 0 {
+		missingVotes = append(missingVotes, votes...)
 	}
 
-	return missingPrevotes, nil
-}
-
-func (fd *FaultDetector) missingPrecommits(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg) ([]*message.Precommit, error) {
-	var missingPrecommits []*message.Precommit
-
-	for _, roundView := range lostSync.RoundsViews {
-		// get missing precommits.
-		presentedPrecommitVal := make(map[common.Hash]struct{})
-		for i, value := range roundView.Precommits {
-
-			if _, ok := presentedPrecommitVal[value]; ok {
-				return nil, errInvalidLostSyncMsg
-			} else {
-				presentedPrecommitVal[value] = struct{}{}
-			}
-
-			presentedSigners := roundView.PrecommitsSigners[i]
-			if presentedSigners == nil {
-				return nil, errInvalidLostSyncMsg
-			}
-
-			// select precommits of the same round with same value but with different presentedSigners
-			precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
-				if uint64(m.R()) == roundView.Round && m.Value() == value {
-					// only with signers which is not in the presentedSigners
-					for _, idx := range m.Signers().FlattenUniq() {
-						if presentedSigners.Bit(idx) == 0 {
-							return true
-						}
-					}
-				}
-				return false
-			})
-
-			if len(precommits) > 0 {
-				missingPrecommits = append(missingPrecommits, precommits...)
-			}
-		}
-		// get precommits of not presented values.
-		precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
-			if uint64(m.R()) == roundView.Round {
-				if _, ok := presentedPrecommitVal[m.Value()]; !ok {
-					return true
-				}
-			}
-			return false
-		})
-		if len(precommits) > 0 {
-			missingPrecommits = append(missingPrecommits, precommits...)
-		}
-	}
-
-	// select precommits of not presented rounds.
-	precommits := fd.msgStore.GetPrecommits(lostSync.Height, func(m *message.Precommit) bool {
-		if _, ok := presentedRounds[uint64(m.R())]; !ok {
-			return true
-		}
-		return false
-	})
-
-	if len(precommits) > 0 {
-		missingPrecommits = append(missingPrecommits, precommits...)
-	}
-
-	return missingPrecommits, nil
+	return missingVotes, nil
 }

--- a/consensus/tendermint/accountability/lost_sync_handler.go
+++ b/consensus/tendermint/accountability/lost_sync_handler.go
@@ -77,26 +77,57 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 		}
 	}
 
-	// prioritized the missing precomits as it could trigger the remote peer step into next round or to commit a value.
-	err = fd.sendMissingPrecommits(presentedRounds, &lostSync, sender)
+	proposals := fd.missingProposals(&lostSync)
+	preCommits, err := fd.missingPrecommits(presentedRounds, &lostSync)
 	if err != nil {
 		fd.logger.Error("Going to suspend peer connection", "err", err, "peer", sender)
 		return err
 	}
 
-	// otherwise, we send missing prevotes to get remote peer change its voting step.
-	err = fd.sendMissingPrevotes(presentedRounds, &lostSync, sender)
+	preVotes, err := fd.missingPrevotes(presentedRounds, &lostSync)
 	if err != nil {
 		fd.logger.Error("Going to suspend per connection", "err", err, "peer", sender)
 		return err
 	}
 
-	// at the end, we send the most heavy msg, the missing proposals.
-	fd.sendMissingProposals(&lostSync, sender)
+	if fd.broadcaster == nil {
+		fd.logger.Warn("p2p protocol handler is not ready yet")
+		return nil
+	}
+
+	peer, ok := fd.broadcaster.FindPeer(sender)
+	if !ok {
+		fd.logger.Debug("no peer connection for sender", "peer", sender)
+		return nil
+	}
+
+	// prioritize the sending of missing proposals.
+	if len(proposals) > 0 {
+		for _, m := range proposals {
+			fd.logger.Info("sending missing proposal to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "VR", m.ValidRound(), "from", fd.address, "to", sender)
+			go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+		}
+	}
+
+	// then sends the missing precommits, as precommits could trigger round rotation or a commitment of a value.
+	if len(preCommits) > 0 {
+		for _, m := range preCommits {
+			fd.logger.Info("sending missing prevote to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
+			go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+		}
+	}
+
+	if len(preVotes) > 0 {
+		for _, m := range preVotes {
+			fd.logger.Info("sending missing prevote to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
+			go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
+		}
+	}
+
 	return nil
 }
 
-func (fd *FaultDetector) sendMissingProposals(lostSync *message.LostSyncMsg, sender common.Address) {
+func (fd *FaultDetector) missingProposals(lostSync *message.LostSyncMsg) []*message.Propose {
 	var missingProposals []*message.Propose
 
 	for _, roundView := range lostSync.RoundsViews {
@@ -111,25 +142,10 @@ func (fd *FaultDetector) sendMissingProposals(lostSync *message.LostSyncMsg, sen
 		}
 	}
 
-	if fd.broadcaster == nil {
-		fd.logger.Warn("p2p protocol handler is not ready yet")
-		return
-	}
-
-	peer, ok := fd.broadcaster.FindPeer(sender)
-	if !ok {
-		fd.logger.Debug("no peer connection from sender", "peer", sender)
-		return
-	}
-
-	for _, m := range missingProposals {
-		fd.logger.Info("sending missing proposal to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "VR", m.ValidRound(), "from", fd.address, "to", sender)
-		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
-	}
-	return
+	return missingProposals
 }
 
-func (fd *FaultDetector) sendMissingPrevotes(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg, sender common.Address) error {
+func (fd *FaultDetector) missingPrevotes(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg) ([]*message.Prevote, error) {
 	var missingPrevotes []*message.Prevote
 	for _, roundView := range lostSync.RoundsViews {
 		// get missing prevotes of the round, they could have different value and different signers.
@@ -137,14 +153,14 @@ func (fd *FaultDetector) sendMissingPrevotes(presentedRounds map[uint64]struct{}
 		for i, value := range roundView.Prevotes {
 
 			if _, ok := presentedPrevoteVal[value]; ok {
-				return errInvalidLostSyncMsg
+				return nil, errInvalidLostSyncMsg
 			} else {
 				presentedPrevoteVal[value] = struct{}{}
 			}
 
 			presentedSigners := roundView.PrevotesSigners[i]
 			if presentedSigners == nil {
-				return errInvalidLostSyncMsg
+				return nil, errInvalidLostSyncMsg
 			}
 
 			// select prevotes of the same round with same value but with different presentedSigners
@@ -190,25 +206,10 @@ func (fd *FaultDetector) sendMissingPrevotes(presentedRounds map[uint64]struct{}
 		missingPrevotes = append(missingPrevotes, prevotes...)
 	}
 
-	if fd.broadcaster == nil {
-		fd.logger.Warn("p2p protocol handler is not ready yet")
-		return nil
-	}
-
-	peer, ok := fd.broadcaster.FindPeer(sender)
-	if !ok {
-		fd.logger.Debug("no peer connection for sender", "peer", sender)
-		return nil
-	}
-
-	for _, m := range missingPrevotes {
-		fd.logger.Info("sending missing prevote to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
-		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
-	}
-	return nil
+	return missingPrevotes, nil
 }
 
-func (fd *FaultDetector) sendMissingPrecommits(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg, sender common.Address) error {
+func (fd *FaultDetector) missingPrecommits(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg) ([]*message.Precommit, error) {
 	var missingPrecommits []*message.Precommit
 
 	for _, roundView := range lostSync.RoundsViews {
@@ -217,14 +218,14 @@ func (fd *FaultDetector) sendMissingPrecommits(presentedRounds map[uint64]struct
 		for i, value := range roundView.Precommits {
 
 			if _, ok := presentedPrecommitVal[value]; ok {
-				return errInvalidLostSyncMsg
+				return nil, errInvalidLostSyncMsg
 			} else {
 				presentedPrecommitVal[value] = struct{}{}
 			}
 
 			presentedSigners := roundView.PrecommitsSigners[i]
 			if presentedSigners == nil {
-				return errInvalidLostSyncMsg
+				return nil, errInvalidLostSyncMsg
 			}
 
 			// select precommits of the same round with same value but with different presentedSigners
@@ -270,21 +271,5 @@ func (fd *FaultDetector) sendMissingPrecommits(presentedRounds map[uint64]struct
 		missingPrecommits = append(missingPrecommits, precommits...)
 	}
 
-	if fd.broadcaster == nil {
-		fd.logger.Warn("p2p protocol handler is not ready yet")
-		return nil
-	}
-
-	peer, ok := fd.broadcaster.FindPeer(sender)
-	if !ok {
-		fd.logger.Debug("no peer connection for sender", "peer", sender)
-		return nil
-	}
-
-	for _, m := range missingPrecommits {
-		fd.logger.Info("sending missing precomit to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
-		go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
-	}
-
-	return nil
+	return missingPrecommits, nil
 }

--- a/consensus/tendermint/accountability/lost_sync_handler.go
+++ b/consensus/tendermint/accountability/lost_sync_handler.go
@@ -14,7 +14,7 @@ import (
 // more over that, future round messages can be synced now and the handling of AskSync msg does not block the consensus
 // engine anymore.
 
-var askSyncInterval = 20 // 20s
+var askSyncInterval = 5 // 5s
 
 var errAskSyncOverRated = errors.New("ask sync over rated")
 

--- a/consensus/tendermint/accountability/lost_sync_handler.go
+++ b/consensus/tendermint/accountability/lost_sync_handler.go
@@ -62,6 +62,9 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 	}
 
 	// sanity checks: no duplicated rounds, and msg set bound checks.
+	if len(lostSync.RoundsViews) > constants.MaxRound {
+		return errInvalidLostSyncMsg
+	}
 	presentedRounds := make(map[uint64]struct{})
 	for _, v := range lostSync.RoundsViews {
 		if v.Round > constants.MaxRound {

--- a/consensus/tendermint/accountability/lost_sync_handler.go
+++ b/consensus/tendermint/accountability/lost_sync_handler.go
@@ -82,7 +82,7 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 		}
 	}
 
-	proposals := fd.missingProposals(&lostSync)
+	proposals := fd.missingProposals(presentedRounds, &lostSync)
 	preCommits, err := fd.missingVotes(presentedRounds, message.PrecommitCode, &lostSync)
 	if err != nil {
 		fd.logger.Error("Going to suspend peer connection", "err", err, "peer", sender)
@@ -117,14 +117,14 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 	// then sends the missing precommits, as precommits could trigger round rotation or a commitment of a value.
 	if len(preCommits) > 0 {
 		for _, m := range preCommits {
-			fd.logger.Info("sending missing prevote to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
+			fd.logger.Info("sending missing precommits to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
 			go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
 		}
 	}
 
 	if len(preVotes) > 0 {
 		for _, m := range preVotes {
-			fd.logger.Info("sending missing prevote to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
+			fd.logger.Info("sending missing prevotes to lost sync peer", "value", m.Value(), "H", m.H(), "R", m.R(), "from", fd.address, "to", sender)
 			go peer.SendRaw(message.NetworkCodes[m.Code()], m.Payload())
 		}
 	}
@@ -133,9 +133,10 @@ func (fd *FaultDetector) handleLostSyncEvent(payload []byte, sender common.Addre
 }
 
 // missingProposals collects all the missing proposals of a consensus instance base on the asker's view.
-func (fd *FaultDetector) missingProposals(lostSync *message.LostSyncMsg) []*message.Propose {
+func (fd *FaultDetector) missingProposals(presentedRounds map[uint64]struct{}, lostSync *message.LostSyncMsg) []*message.Propose {
 	var missingProposals []*message.Propose
 
+	// collect missing proposals for presented rounds.
 	for _, roundView := range lostSync.RoundsViews {
 		// from the asker's round view, if it missed a proposal of that round, then we need to send
 		// any proposal of that round, otherwise we don't send it as the asker already prevoted for a value.
@@ -147,6 +148,18 @@ func (fd *FaultDetector) missingProposals(lostSync *message.LostSyncMsg) []*mess
 				missingProposals = append(missingProposals, proposals...)
 			}
 		}
+	}
+
+	// collected those proposals of the asker's not presented rounds
+	proposals := fd.msgStore.GetProposals(lostSync.Height, func(m *message.Propose) bool {
+		if _, ok := presentedRounds[uint64(m.R())]; !ok {
+			return true
+		}
+		return false
+	})
+
+	if len(proposals) > 0 {
+		missingProposals = append(missingProposals, proposals...)
 	}
 
 	return missingProposals

--- a/consensus/tendermint/accountability/lost_sync_handler.go
+++ b/consensus/tendermint/accountability/lost_sync_handler.go
@@ -37,6 +37,7 @@ func (r *AskSyncRateLimiter) overRated(asker common.Address) bool {
 		return false
 	}
 
+	r.lastRequestTSs[asker] = now
 	timeDiff := now - lastTS
 
 	return timeDiff < int64(askSyncInterval)

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -209,7 +209,7 @@ func (sb *Backend) Broadcast(committee *types.Committee, message message.Msg) {
 	})
 }
 
-func (sb *Backend) AskSync(committee *types.Committee, syncMsg *message.SyncMsg) {
+func (sb *Backend) AskSync(committee *types.Committee, syncMsg *message.LostSyncMsg) {
 	sb.gossiper.AskSync(committee, sb.core.Height().Uint64(), sb.core.Round(), syncMsg)
 }
 

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -210,7 +210,7 @@ func (sb *Backend) Broadcast(committee *types.Committee, message message.Msg) {
 }
 
 func (sb *Backend) AskSync(committee *types.Committee, syncMsg *message.LostSyncMsg) {
-	sb.gossiper.AskSync(committee, sb.core.Height().Uint64(), sb.core.Round(), syncMsg)
+	sb.gossiper.AskSync(committee, syncMsg)
 }
 
 // Gossip implements tendermint.Backend.Gossip

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -209,8 +209,8 @@ func (sb *Backend) Broadcast(committee *types.Committee, message message.Msg) {
 	})
 }
 
-func (sb *Backend) AskSync(committee *types.Committee) {
-	sb.gossiper.AskSync(committee, sb.core.Height().Uint64(), sb.core.Round())
+func (sb *Backend) AskSync(committee *types.Committee, syncMsg *message.SyncMsg) {
+	sb.gossiper.AskSync(committee, sb.core.Height().Uint64(), sb.core.Round(), syncMsg)
 }
 
 // Gossip implements tendermint.Backend.Gossip
@@ -409,7 +409,7 @@ func (sb *Backend) CommitteeEnodes() []string {
 }
 
 // SyncPeer Synchronize new connected peer with current height messages
-func (sb *Backend) SyncPeer(address common.Address) {
+func (sb *Backend) SyncPeer(address common.Address, msgs []message.Msg) {
 	if sb.Broadcaster == nil {
 		return
 	}
@@ -419,9 +419,8 @@ func (sb *Backend) SyncPeer(address common.Address) {
 	if !ok {
 		return
 	}
-	messages := sb.core.CurrentHeightMessages()
-	sb.logger.Debug("sent current height messages", "peer", address, "n", len(messages))
-	for _, msg := range messages {
+	sb.logger.Debug("sent current height messages", "peer", address, "n", len(msgs))
+	for _, msg := range msgs {
 		//We do not save sync messages in the arc cache as recipient could not have been able to process some previous sent.
 		go peer.SendRaw(message.NetworkCodes[msg.Code()], msg.Payload()) //nolint
 	}

--- a/consensus/tendermint/backend/gossiper.go
+++ b/consensus/tendermint/backend/gossiper.go
@@ -109,21 +109,15 @@ func (g *Gossiper) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (g *Gossiper) AskSync(committee *types.Committee, coreHeight uint64, round int64, syncMsg *message.LostSyncMsg) {
+func (g *Gossiper) AskSync(committee *types.Committee, _ uint64, _ int64, syncMsg *message.LostSyncMsg) {
 	encoded, err := rlp.EncodeToBytes(syncMsg)
 	if err != nil {
 		log.Error("Error encoding sync msg", "err", err)
 		return
 	}
 
-	f := message.Fake{FakeHeight: coreHeight, FakeRound: uint64(round)}
-	recipients, err := g.router.Route(committee, f, g.address)
-	if err != nil {
-		log.Error("Error selecting peers members to broadcast sync", "error", err)
-	}
-
 	targets := make([]common.Address, 0, committee.Len())
-	for _, val := range recipients {
+	for _, val := range committee.Members {
 		if val.Address != g.address {
 			targets = append(targets, val.Address)
 		}

--- a/consensus/tendermint/backend/gossiper.go
+++ b/consensus/tendermint/backend/gossiper.go
@@ -109,7 +109,7 @@ func (g *Gossiper) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (g *Gossiper) AskSync(committee *types.Committee, _ uint64, _ int64, syncMsg *message.LostSyncMsg) {
+func (g *Gossiper) AskSync(committee *types.Committee, syncMsg *message.LostSyncMsg) {
 	encoded, err := rlp.EncodeToBytes(syncMsg)
 	if err != nil {
 		log.Error("Error encoding sync msg", "err", err)

--- a/consensus/tendermint/backend/gossiper.go
+++ b/consensus/tendermint/backend/gossiper.go
@@ -16,7 +16,7 @@ import (
 )
 
 type router interface {
-	Route(committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error)
+	Route(broadcaster consensus.Broadcaster, committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error)
 	SetBroadcaster(broadcaster consensus.Broadcaster)
 }
 
@@ -77,7 +77,7 @@ func (g *Gossiper) Gossip(committee *types.Committee, msg message.Msg) {
 	code := message.NetworkCodes[msg.Code()]
 	payload := msg.Payload()
 
-	recipients, err := g.router.Route(committee, msg, g.address)
+	recipients, err := g.router.Route(g.broadcaster, committee, msg, g.address)
 	if err != nil {
 		if !errors.Is(err, consensus.ErrFutureEpochMessage) {
 			log.Debug("No recipients for proposal", "error", err, "height", msg.H())

--- a/consensus/tendermint/backend/gossiper.go
+++ b/consensus/tendermint/backend/gossiper.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"errors"
+	"github.com/autonity/autonity/rlp"
 	"math/big"
 	"time"
 
@@ -108,7 +109,13 @@ func (g *Gossiper) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (g *Gossiper) AskSync(committee *types.Committee, coreHeight uint64, round int64) {
+func (g *Gossiper) AskSync(committee *types.Committee, coreHeight uint64, round int64, syncMsg *message.SyncMsg) {
+	encoded, err := rlp.EncodeToBytes(syncMsg)
+	if err != nil {
+		log.Error("Error encoding sync msg", "err", err)
+		return
+	}
+
 	f := message.Fake{FakeHeight: coreHeight, FakeRound: uint64(round)}
 	recipients, err := g.router.Route(committee, f, g.address)
 	if err != nil {
@@ -138,12 +145,13 @@ func (g *Gossiper) AskSync(committee *types.Committee, coreHeight uint64, round 
 			}
 			count := new(big.Int)
 			for addr, p := range ps {
-				//ask to a quorum nodes to sync, 1 must then be honest and updated
+				// todo: double check if quorum nodes are sufficient for state recovery?
+				// ask to a quorum nodes to sync, 1 must then be honest and updated
 				if count.Cmp(bft.Quorum(committee.TotalVotingPower())) >= 0 {
 					break
 				}
 				g.logger.Debug("Asking sync to", "addr", addr)
-				go p.Send(message.SyncNetworkMsg, []byte{}) //nolint
+				go p.Send(message.SyncNetworkMsg, encoded) //nolint
 
 				member := committee.MemberByAddress(addr)
 				if member == nil {

--- a/consensus/tendermint/backend/gossiper.go
+++ b/consensus/tendermint/backend/gossiper.go
@@ -109,7 +109,7 @@ func (g *Gossiper) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (g *Gossiper) AskSync(committee *types.Committee, coreHeight uint64, round int64, syncMsg *message.SyncMsg) {
+func (g *Gossiper) AskSync(committee *types.Committee, coreHeight uint64, round int64, syncMsg *message.LostSyncMsg) {
 	encoded, err := rlp.EncodeToBytes(syncMsg)
 	if err != nil {
 		log.Error("Error encoding sync msg", "err", err)

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -100,7 +100,8 @@ func (sb *Backend) HandleMsg(sender common.Address, msg p2p.Msg, errCh chan<- er
 			return true, errDecodeFailed
 		}
 		sb.logger.Debug("Received sync message", "from", sender)
-		go sb.Post(events.SyncEvent{Addr: sender, Payload: data})
+		// post the sync message to the event handler, let the handler handle DoS attack vectors.
+		go sb.Post(events.LostSyncEvent{Sender: sender, Payload: data, ErrCh: errCh})
 	case message.AccountabilityNetworkMsg:
 		if !sb.coreRunning.Load() {
 			sb.logger.Debug("Accountability Msg received but core not running")

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -205,7 +205,7 @@ func (sb *Backend) handleDecodedMsg(msg message.Msg, errCh chan<- error, sender 
 
 	// structured relaying happens after the pre-validation, only unknown msg is relayed.
 	if sb.router != nil {
-		go sb.router.Forward(committee, msg, sender)
+		go sb.router.Forward(sb.Broadcaster, committee, msg, sender)
 	}
 
 	// if the sender is jailed, discard its messages

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -86,6 +86,7 @@ func (sb *Backend) HandleMsg(sender common.Address, msg p2p.Msg, errCh chan<- er
 	case message.PrecommitNetworkMsg:
 		return handleConsensusMsg[message.Precommit](sb, sender, msg, errCh)
 	case message.SyncNetworkMsg:
+
 		if !sb.coreRunning.Load() {
 			sb.logger.Debug("Sync message received but core not running")
 			return true, nil // we return nil as we don't want to shut down the connection if core is stopped

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -94,8 +94,13 @@ func (sb *Backend) HandleMsg(sender common.Address, msg p2p.Msg, errCh chan<- er
 			sb.logger.Debug("Ignoring sync message from jailed validator", "from", sender)
 			return true, ErrJailed
 		}
+		var data []byte
+		if err := msg.Decode(&data); err != nil {
+			// this error will freeze peer for 30 seconds by according to dev p2p protocol.
+			return true, errDecodeFailed
+		}
 		sb.logger.Debug("Received sync message", "from", sender)
-		go sb.Post(events.SyncEvent{Addr: sender})
+		go sb.Post(events.SyncEvent{Addr: sender, Payload: data})
 	case message.AccountabilityNetworkMsg:
 		if !sb.coreRunning.Load() {
 			sb.logger.Debug("Accountability Msg received but core not running")

--- a/consensus/tendermint/backend/handler_test.go
+++ b/consensus/tendermint/backend/handler_test.go
@@ -85,7 +85,7 @@ func TestTendermintMessage(t *testing.T) {
 func TestSynchronisationMessage(t *testing.T) {
 	t.Run("engine not running, ignored", func(t *testing.T) {
 		eventMux := event.NewTypeMuxSilent(nil, log.New("backend", "test", "id", 0))
-		sub := eventMux.Subscribe(events.SyncEvent{})
+		sub := eventMux.Subscribe(events.LostSyncEvent{})
 		b := &Backend{
 			database: rawdb.NewMemoryDatabase(),
 			logger:   log.New("backend", "test", "id", 0),
@@ -107,7 +107,7 @@ func TestSynchronisationMessage(t *testing.T) {
 
 	t.Run("engine running, sync returned", func(t *testing.T) {
 		eventMux := event.NewTypeMuxSilent(nil, log.New("backend", "test", "id", 0))
-		sub := eventMux.Subscribe(events.SyncEvent{})
+		sub := eventMux.Subscribe(events.LostSyncEvent{})
 		b := &Backend{
 			database: rawdb.NewMemoryDatabase(),
 			logger:   log.New("backend", "test", "id", 0),

--- a/consensus/tendermint/core/constants/constant.go
+++ b/consensus/tendermint/core/constants/constant.go
@@ -3,4 +3,5 @@ package constants
 const (
 	MaxRound                      = 999 // consequence of backlog priority
 	ProposerElectionCycleConstant = 99  // seed for controlling proposer election repetition
+	AskSyncInterval               = 5   // the interval in seconds to check the liveness and rise AskSync request.
 )

--- a/consensus/tendermint/core/core.go
+++ b/consensus/tendermint/core/core.go
@@ -656,7 +656,6 @@ func (c *Core) VotesPowerFor(h uint64, r int64, code uint8, v common.Hash) *mess
 	return power
 }
 
-// TODO: when we sync a peer, should we send him also the future round messages?
 func (c *Core) CurrentHeightMessages() []message.Msg {
 	return c.messages.All()
 }

--- a/consensus/tendermint/core/core.go
+++ b/consensus/tendermint/core/core.go
@@ -112,7 +112,6 @@ type Core struct {
 	candidateBlockCh    chan events.NewCandidateBlockEvent
 	committedCh         chan events.CommitEvent
 	timeoutEventSub     *event.TypeMuxSubscription
-	syncEventSub        *event.TypeMuxSubscription
 	futureProposalTimer *time.Timer
 	stopped             chan struct{}
 	syncState           *SyncState
@@ -654,10 +653,6 @@ func (c *Core) VotesPowerFor(h uint64, r int64, code uint8, v common.Hash) *mess
 		c.logger.Crit("unknown message code", "code", code)
 	}
 	return power
-}
-
-func (c *Core) CurrentHeightMessages() []message.Msg {
-	return c.messages.All()
 }
 
 func (c *Core) Backend() interfaces.Backend {

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/autonity/autonity/metrics"
 )
 
-// todo: resolve proper tendermint state synchronization timeout from block period.
 const syncTimeOut = 30 * time.Second
 
 // Start implements core.Tendermint.Start

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -307,7 +307,7 @@ func (c *Core) livenessTrackerLoop(ctx context.Context) {
 eventLoop:
 	for {
 		select {
-		case <-time.After(time.Second * 5): //check for sync every 5 seconds
+		case <-time.After(time.Second * constants.AskSyncInterval): //check for sync every 5 seconds
 
 			if time.Since(c.syncState.GetLastValidMsgTime()) < c.syncState.GetSyncTimeOut() {
 				c.logger.Debug("Sync timeout not reached yet", "last valid message received", c.syncState.GetLastValidMsgTime(), "sync timeout", c.syncState.GetSyncTimeOut())

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -320,8 +320,8 @@ eventLoop:
 
 			// we only ask for sync if the current view stayed the same for the interval syncTimeOut
 			if currentHeight.Cmp(height) == 0 && currentRound == round {
-				c.logger.Warn("⚠️ Consensus liveliness lost")
-				c.logger.Warn("Broadcasting sync request..")
+				c.logger.Warn("⚠️ Consensus liveliness lost", "node", c.Address(), "height", height, "round", currentRound, "step", c.Step())
+				c.logger.Warn("Broadcasting sync request..", "node", c.Address(), "height", height, "round", currentRound, "step", c.Step())
 				syncMsg = c.snapshotLostSyncMsg()
 				c.backend.AskSync(c.committee.Committee(), syncMsg)
 				c.syncState.SetOutOfSync(true)

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -147,7 +147,7 @@ func (c *Core) GossipComplexAggregate(code uint8, round int64, value common.Hash
 }
 
 func (c *Core) mainEventLoop(ctx context.Context) {
-	go c.syncLoop(ctx)
+	go c.livenessTrackerLoop(ctx)
 
 eventLoop:
 	for {
@@ -291,7 +291,7 @@ eventLoop:
 	c.stopped <- struct{}{}
 }
 
-func (c *Core) syncLoop(ctx context.Context) {
+func (c *Core) livenessTrackerLoop(ctx context.Context) {
 	/*
 		this method is responsible for asking the network to send us the current consensus state
 		and to process sync queries events.
@@ -331,7 +331,7 @@ eventLoop:
 			height = currentHeight
 
 		case <-ctx.Done():
-			c.logger.Debug("syncLoop is stopped", "event", ctx.Err())
+			c.logger.Debug("livenessTrackerLoop is stopped", "event", ctx.Err())
 			break eventLoop
 
 		}

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -299,13 +299,13 @@ func (c *Core) syncLoop(ctx context.Context) {
 		and to process sync queries events.
 	*/
 	// syncTime out should be dynamic based on the current round timer
-	// TODO: think about sending the bitmap of messages you currently have in sync request
 
 	round := c.Round()
 	height := c.Height()
 
 	// Ask for sync when the engine starts
-	c.backend.AskSync(c.committee.Committee())
+	syncMsg := c.snapshotSyncMsg()
+	c.backend.AskSync(c.committee.Committee(), syncMsg)
 
 eventLoop:
 	for {
@@ -325,7 +325,8 @@ eventLoop:
 			if currentHeight.Cmp(height) == 0 && currentRound == round {
 				c.logger.Warn("⚠️ Consensus liveliness lost")
 				c.logger.Warn("Broadcasting sync request..")
-				c.backend.AskSync(c.committee.Committee())
+				syncMsg = c.snapshotSyncMsg()
+				c.backend.AskSync(c.committee.Committee(), syncMsg)
 				c.syncState.SetOutOfSync(true)
 			}
 			round = currentRound
@@ -341,7 +342,8 @@ eventLoop:
 				continue
 			}
 			c.logger.Debug("Processing sync message", "from", event.Addr)
-			c.backend.SyncPeer(event.Addr)
+			msgs := c.msgsNotSynced(syncMsg)
+			c.backend.SyncPeer(event.Addr, msgs)
 		case <-ctx.Done():
 			c.logger.Debug("syncLoop is stopped", "event", ctx.Err())
 			break eventLoop

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -64,14 +64,12 @@ func (c *Core) subscribeEvents() {
 	c.candidateBlockCh = make(chan events.NewCandidateBlockEvent, 1)
 	c.committedCh = make(chan events.CommitEvent, 1)
 	c.timeoutEventSub = c.backend.Subscribe(TimeoutEvent{})
-	c.syncEventSub = c.backend.Subscribe(events.SyncEvent{})
 }
 
 // Unsubscribe all
 func (c *Core) unsubscribeEvents() {
 	c.messageSub.Unsubscribe()
 	c.timeoutEventSub.Unsubscribe()
-	c.syncEventSub.Unsubscribe()
 }
 
 func shouldDisconnectSender(err error) bool {
@@ -304,7 +302,7 @@ func (c *Core) syncLoop(ctx context.Context) {
 	height := c.Height()
 
 	// Ask for sync when the engine starts
-	syncMsg := c.snapshotSyncMsg()
+	syncMsg := c.snapshotLostSyncMsg()
 	c.backend.AskSync(c.committee.Committee(), syncMsg)
 
 eventLoop:
@@ -325,25 +323,13 @@ eventLoop:
 			if currentHeight.Cmp(height) == 0 && currentRound == round {
 				c.logger.Warn("⚠️ Consensus liveliness lost")
 				c.logger.Warn("Broadcasting sync request..")
-				syncMsg = c.snapshotSyncMsg()
+				syncMsg = c.snapshotLostSyncMsg()
 				c.backend.AskSync(c.committee.Committee(), syncMsg)
 				c.syncState.SetOutOfSync(true)
 			}
 			round = currentRound
 			height = currentHeight
 
-		case ev, ok := <-c.syncEventSub.Chan():
-			if !ok {
-				break eventLoop
-			}
-			event := ev.Data.(events.SyncEvent)
-			if c.syncState.IsOutOfSync() {
-				c.logger.Info("sync request received while we are out of sync, dropping", "from", event.Addr)
-				continue
-			}
-			c.logger.Debug("Processing sync message", "from", event.Addr)
-			msgs := c.msgsNotSynced(syncMsg)
-			c.backend.SyncPeer(event.Addr, msgs)
 		case <-ctx.Done():
 			c.logger.Debug("syncLoop is stopped", "event", ctx.Err())
 			break eventLoop

--- a/consensus/tendermint/core/interfaces/core_backend.go
+++ b/consensus/tendermint/core/interfaces/core_backend.go
@@ -119,8 +119,8 @@ type Router interface {
 	Start(ctx context.Context, chain *ethcore.BlockChain)
 	Stop()
 	SetBroadcaster(broadcaster consensus.Broadcaster)
-	Route(committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error)
-	Forward(committee *types.Committee, m message.Msg, sender common.Address)
+	Route(broadcaster consensus.Broadcaster, committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error)
+	Forward(broadcaster consensus.Broadcaster, committee *types.Committee, m message.Msg, sender common.Address)
 }
 
 type EventDispatcher interface {

--- a/consensus/tendermint/core/interfaces/core_backend.go
+++ b/consensus/tendermint/core/interfaces/core_backend.go
@@ -25,7 +25,7 @@ type Backend interface {
 
 	AddSeal(block *types.Block) (*types.Block, error)
 
-	AskSync(committee *types.Committee)
+	AskSync(committee *types.Committee, syncMsg *message.SyncMsg)
 
 	// Broadcast sends a message to all validators (include self)
 	Broadcast(committee *types.Committee, message message.Msg)
@@ -58,7 +58,7 @@ type Backend interface {
 
 	Subscribe(types ...any) *event.TypeMuxSubscription
 
-	SyncPeer(address common.Address)
+	SyncPeer(address common.Address, msgs []message.Msg)
 
 	// VerifyProposal verifies the proposal. If a consensus.ErrFutureBlock error is returned,
 	// the time difference of the proposal and current time is also returned.

--- a/consensus/tendermint/core/interfaces/core_backend.go
+++ b/consensus/tendermint/core/interfaces/core_backend.go
@@ -25,7 +25,7 @@ type Backend interface {
 
 	AddSeal(block *types.Block) (*types.Block, error)
 
-	AskSync(committee *types.Committee, syncMsg *message.SyncMsg)
+	AskSync(committee *types.Committee, syncMsg *message.LostSyncMsg)
 
 	// Broadcast sends a message to all validators (include self)
 	Broadcast(committee *types.Committee, message message.Msg)
@@ -107,7 +107,6 @@ type Core interface {
 	Precommiter() Precommiter
 	Height() *big.Int
 	Round() int64
-	CurrentHeightMessages() []message.Msg
 
 	// Used by the aggregator
 	Power(h uint64, r int64) *message.AggregatedPower

--- a/consensus/tendermint/core/interfaces/core_backend_mock.go
+++ b/consensus/tendermint/core/interfaces/core_backend_mock.go
@@ -81,15 +81,15 @@ func (mr *MockBackendMockRecorder) Address() *gomock.Call {
 }
 
 // AskSync mocks base method.
-func (m *MockBackend) AskSync(committee *types.Committee) {
+func (m *MockBackend) AskSync(committee *types.Committee, syncMsg *message.SyncMsg) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AskSync", committee)
+	m.ctrl.Call(m, "AskSync", committee, syncMsg)
 }
 
 // AskSync indicates an expected call of AskSync.
-func (mr *MockBackendMockRecorder) AskSync(committee any) *gomock.Call {
+func (mr *MockBackendMockRecorder) AskSync(committee, syncMsg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskSync", reflect.TypeOf((*MockBackend)(nil).AskSync), committee)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskSync", reflect.TypeOf((*MockBackend)(nil).AskSync), committee, syncMsg)
 }
 
 // BlockChain mocks base method.
@@ -404,15 +404,15 @@ func (mr *MockBackendMockRecorder) Subscribe(types ...any) *gomock.Call {
 }
 
 // SyncPeer mocks base method.
-func (m *MockBackend) SyncPeer(address common.Address) {
+func (m *MockBackend) SyncPeer(address common.Address, msgs []message.Msg) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SyncPeer", address)
+	m.ctrl.Call(m, "SyncPeer", address, msgs)
 }
 
 // SyncPeer indicates an expected call of SyncPeer.
-func (mr *MockBackendMockRecorder) SyncPeer(address any) *gomock.Call {
+func (mr *MockBackendMockRecorder) SyncPeer(address, msgs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPeer", reflect.TypeOf((*MockBackend)(nil).SyncPeer), address)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPeer", reflect.TypeOf((*MockBackend)(nil).SyncPeer), address, msgs)
 }
 
 // VerifyProposal mocks base method.

--- a/consensus/tendermint/core/interfaces/core_backend_mock.go
+++ b/consensus/tendermint/core/interfaces/core_backend_mock.go
@@ -81,7 +81,7 @@ func (mr *MockBackendMockRecorder) Address() *gomock.Call {
 }
 
 // AskSync mocks base method.
-func (m *MockBackend) AskSync(committee *types.Committee, syncMsg *message.SyncMsg) {
+func (m *MockBackend) AskSync(committee *types.Committee, syncMsg *message.LostSyncMsg) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AskSync", committee, syncMsg)
 }
@@ -479,20 +479,6 @@ func (m *MockCore) CoreState() CoreState {
 func (mr *MockCoreMockRecorder) CoreState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CoreState", reflect.TypeOf((*MockCore)(nil).CoreState))
-}
-
-// CurrentHeightMessages mocks base method.
-func (m *MockCore) CurrentHeightMessages() []message.Msg {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CurrentHeightMessages")
-	ret0, _ := ret[0].([]message.Msg)
-	return ret0
-}
-
-// CurrentHeightMessages indicates an expected call of CurrentHeightMessages.
-func (mr *MockCoreMockRecorder) CurrentHeightMessages() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentHeightMessages", reflect.TypeOf((*MockCore)(nil).CurrentHeightMessages))
 }
 
 // EventCh mocks base method.

--- a/consensus/tendermint/core/interfaces/gossiper.go
+++ b/consensus/tendermint/core/interfaces/gossiper.go
@@ -10,7 +10,7 @@ import (
 
 type Gossiper interface {
 	Gossip(committee *types.Committee, message message.Msg)
-	AskSync(committee *types.Committee, coreHeight uint64, round int64, syncMsg *message.SyncMsg)
+	AskSync(committee *types.Committee, coreHeight uint64, round int64, syncMsg *message.LostSyncMsg)
 	SetBroadcaster(broadcaster consensus.Broadcaster)
 	Broadcaster() consensus.Broadcaster
 	KnownMessages() *fixsizecache.Cache[common.Hash, bool]

--- a/consensus/tendermint/core/interfaces/gossiper.go
+++ b/consensus/tendermint/core/interfaces/gossiper.go
@@ -10,7 +10,7 @@ import (
 
 type Gossiper interface {
 	Gossip(committee *types.Committee, message message.Msg)
-	AskSync(committee *types.Committee, coreHeight uint64, round int64)
+	AskSync(committee *types.Committee, coreHeight uint64, round int64, syncMsg *message.SyncMsg)
 	SetBroadcaster(broadcaster consensus.Broadcaster)
 	Broadcaster() consensus.Broadcaster
 	KnownMessages() *fixsizecache.Cache[common.Hash, bool]

--- a/consensus/tendermint/core/interfaces/gossiper.go
+++ b/consensus/tendermint/core/interfaces/gossiper.go
@@ -10,7 +10,7 @@ import (
 
 type Gossiper interface {
 	Gossip(committee *types.Committee, message message.Msg)
-	AskSync(committee *types.Committee, coreHeight uint64, round int64, syncMsg *message.LostSyncMsg)
+	AskSync(committee *types.Committee, syncMsg *message.LostSyncMsg)
 	SetBroadcaster(broadcaster consensus.Broadcaster)
 	Broadcaster() consensus.Broadcaster
 	KnownMessages() *fixsizecache.Cache[common.Hash, bool]

--- a/consensus/tendermint/core/message/round_messages.go
+++ b/consensus/tendermint/core/message/round_messages.go
@@ -40,8 +40,8 @@ func (s *Map) Snapshot() []*RoundMsgView {
 	s.RLock()
 	defer s.RUnlock()
 	var views []*RoundMsgView
-	for _, v := range s.internal {
-		views = append(views, v.Snapshot())
+	for r, v := range s.internal {
+		views = append(views, v.Snapshot(r))
 	}
 	return views
 }
@@ -224,11 +224,11 @@ func (s *RoundMessages) AllMessages() []Msg {
 	return result
 }
 
-func (s *RoundMessages) Snapshot() *RoundMsgView {
+func (s *RoundMessages) Snapshot(round int64) *RoundMsgView {
 	s.RLock()
 	defer s.RUnlock()
 	view := &RoundMsgView{}
-	view.Round = uint64(s.Proposal().R())
+	view.Round = uint64(round)
 
 	if s.proposal != nil {
 		view.Proposal = s.proposal.Value()

--- a/consensus/tendermint/core/message/round_messages.go
+++ b/consensus/tendermint/core/message/round_messages.go
@@ -36,6 +36,16 @@ func (s *Map) GetOrCreate(round int64) *RoundMessages {
 	return state
 }
 
+func (s *Map) Snapshot() []*RoundMsgView {
+	s.RLock()
+	defer s.RUnlock()
+	var views []*RoundMsgView
+	for _, v := range s.internal {
+		views = append(views, v.Snapshot())
+	}
+	return views
+}
+
 // TODO: this function has a mutex that can be taken by:
 // 1. the core routine
 // 2. the routine that syncs other peers
@@ -216,4 +226,52 @@ func (s *RoundMessages) AllMessages() []Msg {
 	result = append(result, prevotes...)
 	result = append(result, precommits...)
 	return result
+}
+
+func (s *RoundMessages) Snapshot() *RoundMsgView {
+	s.RLock()
+	defer s.RUnlock()
+	view := &RoundMsgView{}
+	view.Round = uint64(s.Proposal().R())
+
+	if s.proposal != nil {
+		view.Proposal = s.proposal.Value()
+	}
+
+	if s.prevotes != nil {
+		values, signers := s.prevotes.Snapshot()
+		view.Prevotes = values
+		view.PrevotesSigners = signers
+	}
+
+	if s.precommits != nil {
+		values, signers := s.precommits.Snapshot()
+		view.Precommits = values
+		view.PrecommitsSigners = signers
+	}
+	return view
+}
+
+type RoundMsgView struct {
+	Round uint64
+
+	// received proposal, normally only one, could be multiple if proposer equivocated.
+	// different proposals will be exchanged if one find there is an equivocated one.
+	Proposal common.Hash
+
+	// prevoted values in the round
+	Prevotes []common.Hash
+	// signers for each prevoted values listed in the Prevotes slice.
+	PrevotesSigners []*big.Int
+
+	// precommitted values in the round
+	Precommits []common.Hash
+	// signders for each precommitted values listed in the Precommit slice.
+	PrecommitsSigners []*big.Int
+}
+
+// SyncMsg carries all the msgs' views, include future rounds of current consensus engine for tendermint state recovery.
+type SyncMsg struct {
+	Height      uint64
+	RoundsViews []*RoundMsgView
 }

--- a/consensus/tendermint/core/message/round_messages.go
+++ b/consensus/tendermint/core/message/round_messages.go
@@ -46,10 +46,6 @@ func (s *Map) Snapshot() []*RoundMsgView {
 	return views
 }
 
-// TODO: this function has a mutex that can be taken by:
-// 1. the core routine
-// 2. the routine that syncs other peers
-// can this be exploited by a malicious peer to slow Core down (by requesting ask sync lots of times)
 func (s *Map) All() []Msg {
 	s.RLock()
 	defer s.RUnlock()
@@ -270,8 +266,8 @@ type RoundMsgView struct {
 	PrecommitsSigners []*big.Int
 }
 
-// SyncMsg carries all the msgs' views, include future rounds of current consensus engine for tendermint state recovery.
-type SyncMsg struct {
+// LostSyncMsg carries all the msgs' views, include future rounds of current consensus engine for tendermint state recovery.
+type LostSyncMsg struct {
 	Height      uint64
 	RoundsViews []*RoundMsgView
 }

--- a/consensus/tendermint/core/message/round_messages.go
+++ b/consensus/tendermint/core/message/round_messages.go
@@ -251,7 +251,7 @@ func (s *RoundMessages) Snapshot(round int64) *RoundMsgView {
 type RoundMsgView struct {
 	Round uint64
 
-	// received proposal, normally only one, could be multiple if proposer equivocated.
+	// the 1st received proposal that the client prevoted, normally only one, could be multiple if proposer equivocated.
 	// different proposals will be exchanged if one find there is an equivocated one.
 	Proposal common.Hash
 

--- a/consensus/tendermint/core/message/set.go
+++ b/consensus/tendermint/core/message/set.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"math/big"
 	"sync"
 
 	"github.com/autonity/autonity/common"
@@ -108,4 +109,19 @@ func (s *Set) VotesFor(blockHash common.Hash) []Vote {
 	defer s.RUnlock()
 
 	return s.votes[blockHash]
+}
+
+func (s *Set) Snapshot() ([]common.Hash, []*big.Int) {
+	s.RLock()
+	defer s.RUnlock()
+
+	values := make([]common.Hash, 0, len(s.powers))
+	signers := make([]*big.Int, 0, len(s.powers))
+	i := 0
+	for v, votes := range s.powers {
+		values[i] = v
+		signers[i] = new(big.Int).Set(votes.Signers())
+	}
+
+	return values, signers
 }

--- a/consensus/tendermint/core/message/set.go
+++ b/consensus/tendermint/core/message/set.go
@@ -121,6 +121,7 @@ func (s *Set) Snapshot() ([]common.Hash, []*big.Int) {
 	for v, votes := range s.powers {
 		values[i] = v
 		signers[i] = new(big.Int).Set(votes.Signers())
+		i++
 	}
 
 	return values, signers

--- a/consensus/tendermint/core/message/set.go
+++ b/consensus/tendermint/core/message/set.go
@@ -115,13 +115,11 @@ func (s *Set) Snapshot() ([]common.Hash, []*big.Int) {
 	s.RLock()
 	defer s.RUnlock()
 
-	values := make([]common.Hash, 0, len(s.powers))
-	signers := make([]*big.Int, 0, len(s.powers))
-	i := 0
+	var values []common.Hash
+	var signers []*big.Int
 	for v, votes := range s.powers {
-		values[i] = v
-		signers[i] = new(big.Int).Set(votes.Signers())
-		i++
+		values = append(values, v)
+		signers = append(signers, new(big.Int).Set(votes.Signers()))
 	}
 
 	return values, signers

--- a/consensus/tendermint/core/msg_store.go
+++ b/consensus/tendermint/core/msg_store.go
@@ -203,6 +203,36 @@ func (ms *MsgStore) GetProposals(height uint64, query func(*message.Propose) boo
 	return result
 }
 
+func (ms *MsgStore) GetVotes(height uint64, step uint8, query func(vote message.Vote) bool) []message.Vote {
+	ms.RLock()
+	defer ms.RUnlock()
+	var result []message.Vote
+	_, ok := ms.prevotes[height]
+	if !ok {
+		return result
+	}
+
+	if step == message.PrevoteCode {
+		for _, prevote := range ms.prevotes[height] {
+			if query(prevote) {
+				result = append(result, prevote)
+			}
+		}
+		return result
+	}
+
+	if step == message.PrecommitCode {
+		for _, precommit := range ms.precommits[height] {
+			if query(precommit) {
+				result = append(result, precommit)
+			}
+		}
+		return result
+	}
+
+	return result
+}
+
 func (ms *MsgStore) GetPrevotes(height uint64, query func(*message.Prevote) bool) []*message.Prevote {
 	ms.RLock()
 	defer ms.RUnlock()

--- a/consensus/tendermint/core/sync_msg.go
+++ b/consensus/tendermint/core/sync_msg.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"github.com/autonity/autonity/common"
+	"github.com/autonity/autonity/consensus/tendermint/core/message"
+	"math/big"
+)
+
+// msgsNotSynced filter out those missing msg of the remote sync asker.
+func (c *Core) msgsNotSynced(syncMsg *message.SyncMsg) []message.Msg {
+	// todo: filter out those messages round by round from local msg store.
+
+	return nil
+}
+
+func (c *Core) snapshotSyncMsg() *message.SyncMsg {
+	msg := &message.SyncMsg{}
+	msg.Height = c.Height().Uint64()
+	msg.RoundsViews = c.Messages().Snapshot()
+
+	// and future rounds
+	future := c.futureRoundSnapshot()
+	if len(future) > 0 {
+		msg.RoundsViews = append(msg.RoundsViews, future...)
+	}
+
+	return msg
+}
+
+func (c *Core) futureRoundSnapshot() []*message.RoundMsgView {
+	c.futureRoundLock.RLock()
+	defer c.futureRoundLock.RUnlock()
+
+	var views []*message.RoundMsgView
+
+	for k, roundMsgs := range c.futureRound {
+		roundView := &message.RoundMsgView{}
+		roundView.Round = uint64(k)
+
+		preVoteSigners := make(map[common.Hash]*message.AggregatedPower)
+		preCommitSigners := make(map[common.Hash]*message.AggregatedPower)
+
+		for _, m := range roundMsgs {
+			if m.Code() == message.ProposalCode {
+				roundView.Proposal = m.Value()
+			}
+
+			if m.Code() == message.PrevoteCode {
+				value := m.Value()
+				_, ok := preVoteSigners[value]
+				if !ok {
+					preVoteSigners[value] = message.NewAggregatedPower()
+				}
+				for index, power := range m.(message.Vote).Signers().Powers() {
+					preVoteSigners[value].Set(index, power)
+				}
+			}
+
+			if m.Code() == message.PrecommitCode {
+				value := m.Value()
+				_, ok := preCommitSigners[value]
+				if !ok {
+					preCommitSigners[value] = message.NewAggregatedPower()
+				}
+				for index, power := range m.(message.Vote).Signers().Powers() {
+					preCommitSigners[value].Set(index, power)
+				}
+			}
+		}
+
+		var preVotes []common.Hash
+		var preVoteSigns []*big.Int
+		for v, s := range preVoteSigners {
+			preVotes = append(preVotes, v)
+			preVoteSigns = append(preVoteSigns, s.Signers())
+		}
+
+		roundView.Prevotes = preVotes
+		roundView.PrevotesSigners = preVoteSigns
+
+		var preCommits []common.Hash
+		var preCommitSigns []*big.Int
+		for v, s := range preCommitSigners {
+			preCommits = append(preCommits, v)
+			preCommitSigns = append(preCommitSigns, s.Signers())
+		}
+		roundView.Precommits = preCommits
+		roundView.PrecommitsSigners = preCommitSigns
+
+		views = append(views, roundView)
+	}
+
+	return views
+}

--- a/consensus/tendermint/core/sync_msg.go
+++ b/consensus/tendermint/core/sync_msg.go
@@ -6,15 +6,8 @@ import (
 	"math/big"
 )
 
-// msgsNotSynced filter out those missing msg of the remote sync asker.
-func (c *Core) msgsNotSynced(syncMsg *message.SyncMsg) []message.Msg {
-	// todo: filter out those messages round by round from local msg store.
-
-	return nil
-}
-
-func (c *Core) snapshotSyncMsg() *message.SyncMsg {
-	msg := &message.SyncMsg{}
+func (c *Core) snapshotLostSyncMsg() *message.LostSyncMsg {
+	msg := &message.LostSyncMsg{}
 	msg.Height = c.Height().Uint64()
 	msg.RoundsViews = c.Messages().Snapshot()
 

--- a/consensus/tendermint/core/sync_msg_test.go
+++ b/consensus/tendermint/core/sync_msg_test.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"github.com/autonity/autonity/common"
+	"github.com/autonity/autonity/consensus/tendermint/core/message"
+	"github.com/autonity/autonity/rlp"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+)
+
+func TestSyncMsg(t *testing.T) {
+	round1 := &message.RoundMsgView{
+		Round:             1,
+		Proposal:          common.HexToHash("0x1234"),
+		Prevotes:          []common.Hash{common.HexToHash("0xabcd"), common.HexToHash("0xefgh")},
+		PrevotesSigners:   []*big.Int{big.NewInt(1), big.NewInt(2)},
+		Precommits:        []common.Hash{common.HexToHash("0xijkl")},
+		PrecommitsSigners: []*big.Int{big.NewInt(3)},
+	}
+
+	round2 := &message.RoundMsgView{
+		Round:             2,
+		Proposal:          common.Hash{},
+		Prevotes:          []common.Hash{},
+		PrevotesSigners:   []*big.Int{},
+		Precommits:        []common.Hash{},
+		PrecommitsSigners: []*big.Int{},
+	}
+
+	syncMsg := &message.SyncMsg{
+		Height:      100,
+		RoundsViews: []*message.RoundMsgView{round1, round2},
+	}
+
+	encoded, err := rlp.EncodeToBytes(syncMsg)
+	require.NoError(t, err)
+
+	var decodedSyncMsg message.SyncMsg
+	err = rlp.DecodeBytes(encoded, &decodedSyncMsg)
+	require.NoError(t, err)
+
+	require.Equal(t, syncMsg.Height, decodedSyncMsg.Height)
+	require.Equal(t, len(syncMsg.RoundsViews), len(decodedSyncMsg.RoundsViews))
+
+	for i := range syncMsg.RoundsViews {
+		round1 := syncMsg.RoundsViews[i]
+		round2 := decodedSyncMsg.RoundsViews[i]
+
+		require.Equal(t, round1.Round, round2.Round)
+		require.Equal(t, round1.Proposal, round2.Proposal)
+
+		require.Equal(t, len(round1.Prevotes), len(round2.Prevotes))
+		for j := range round1.Prevotes {
+			require.Equal(t, round1.Prevotes[j], round2.Prevotes[j])
+		}
+
+		require.Equal(t, len(round1.PrevotesSigners), len(round2.PrevotesSigners))
+		for j := range round1.PrevotesSigners {
+			require.Equal(t, round1.PrevotesSigners[j].String(), round2.PrevotesSigners[j].String())
+		}
+
+		require.Equal(t, len(round1.Precommits), len(round2.Precommits))
+		for j := range round1.Precommits {
+			require.Equal(t, round1.Precommits[j], round2.Precommits[j])
+		}
+
+		require.Equal(t, len(round1.PrecommitsSigners), len(round2.PrecommitsSigners))
+		for j := range round1.PrecommitsSigners {
+			require.Equal(t, round1.PrecommitsSigners[j].String(), round2.PrecommitsSigners[j].String())
+		}
+	}
+}

--- a/consensus/tendermint/core/sync_msg_test.go
+++ b/consensus/tendermint/core/sync_msg_test.go
@@ -28,7 +28,7 @@ func TestSyncMsg(t *testing.T) {
 		PrecommitsSigners: []*big.Int{},
 	}
 
-	syncMsg := &message.SyncMsg{
+	syncMsg := &message.LostSyncMsg{
 		Height:      100,
 		RoundsViews: []*message.RoundMsgView{round1, round2},
 	}
@@ -36,7 +36,7 @@ func TestSyncMsg(t *testing.T) {
 	encoded, err := rlp.EncodeToBytes(syncMsg)
 	require.NoError(t, err)
 
-	var decodedSyncMsg message.SyncMsg
+	var decodedSyncMsg message.LostSyncMsg
 	err = rlp.DecodeBytes(encoded, &decodedSyncMsg)
 	require.NoError(t, err)
 

--- a/consensus/tendermint/events/events.go
+++ b/consensus/tendermint/events/events.go
@@ -144,9 +144,10 @@ func (f FuturePowerChangeEvent) Value() common.Hash {
 	panic("not implemented")
 }
 
-type SyncEvent struct {
-	Addr    common.Address
+type LostSyncEvent struct {
+	Sender  common.Address
 	Payload []byte
+	ErrCh   chan<- error
 }
 
 type AccountabilityEvent struct {

--- a/consensus/tendermint/events/events.go
+++ b/consensus/tendermint/events/events.go
@@ -145,7 +145,8 @@ func (f FuturePowerChangeEvent) Value() common.Hash {
 }
 
 type SyncEvent struct {
-	Addr common.Address
+	Addr    common.Address
+	Payload []byte
 }
 
 type AccountabilityEvent struct {

--- a/consensus/tendermint/latency/clustering.go
+++ b/consensus/tendermint/latency/clustering.go
@@ -2,6 +2,7 @@ package latency
 
 import (
 	"bytes"
+	"github.com/autonity/autonity/consensus"
 	"math"
 	"math/rand"
 	"sort"
@@ -57,27 +58,40 @@ func (c *Clusters) clusterContaining(address common.Address) int {
 }
 
 // selectK selects pseudo random k members from each cluster exclude the selected cluster.
-func (c *Clusters) selectK(k int, seed int64, excepted int) []common.Address {
+func (c *Clusters) selectK(broadcaster consensus.Broadcaster, k int, seed int64, excepted int) []common.Address {
 	var result []common.Address
 	r := rand.New(rand.NewSource(seed))
-	for i, cluster := range c.base {
+
+	for i, nodes := range c.base {
 		if i == excepted {
 			continue
 		}
 
-		if len(cluster) <= k {
-			result = append(result, cluster...)
+		if len(nodes) <= k {
+			result = append(result, nodes...)
 		} else {
-			selected := make(map[int]struct{})
-			for j := 0; j < k; j++ {
-				index := r.Intn(len(cluster))
-				for _, ok := selected[index]; ok; {
-					index = r.Intn(len(cluster))
+			selectedIndices := make(map[int]struct{})
+			count := 0
+			var selectedNodes []common.Address
+			for len(selectedNodes) < k && count < len(nodes) {
+				index := r.Intn(len(nodes))
+				if _, ok := selectedIndices[index]; !ok {
+					count++
+					_, connected := broadcaster.FindPeer(nodes[index])
+					if connected {
+						selectedIndices[index] = struct{}{}
+						selectedNodes = append(selectedNodes, nodes[index])
+					}
 				}
-				result = append(result, cluster[index])
+			}
+
+			if len(selectedNodes) > 0 {
+				result = append(result, selectedNodes...)
 			}
 		}
+
 	}
+
 	return result
 }
 

--- a/consensus/tendermint/latency/routing.go
+++ b/consensus/tendermint/latency/routing.go
@@ -112,6 +112,10 @@ func (r *Router) PeerSelector() PeerSelector {
 
 // Route just select recipients from the clusters, it does not do the message sending.
 func (r *Router) Route(committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error) {
+	// no route for small network.
+	if len(committee.Members) < ScaleThresholdForClustering {
+		return committee.Members, nil
+	}
 	return r.PeerSelector().SelectPeers(committee, msg, from)
 }
 
@@ -268,9 +272,6 @@ func (r *Router) resolveClusters(h uint64) (*Clusters, error) {
 
 // buildDefaultClusters partitions the committee into default clusters
 func (r *Router) buildDefaultClusters(committee []common.Address) *Clusters {
-	if len(committee) <= ScaleThresholdForClustering {
-		return nil
-	}
 	numClusters := numClustersFor(len(committee))
 	clusters := make([][]common.Address, numClusters)
 	for i, addr := range committee {

--- a/consensus/tendermint/latency/routing.go
+++ b/consensus/tendermint/latency/routing.go
@@ -41,7 +41,7 @@ var HorizontalRelayingRedundancy = 1
 var MeasurementWindow = 2000 // The time window in Millisecond to measure the latency of peers at the beginning of an epoch.
 
 type PeerSelector interface {
-	SelectPeers(committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error)
+	SelectPeers(broadcaster consensus.Broadcaster, committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error)
 }
 
 type Router struct {
@@ -110,18 +110,18 @@ func (r *Router) PeerSelector() PeerSelector {
 
 // Exported functions
 
-// Route just select recipients from the clusters, it does not do the message sending.
-func (r *Router) Route(committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error) {
+// Route just select active/connected recipients from the clusters, it does not do the message sending.
+func (r *Router) Route(broadcaster consensus.Broadcaster, committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error) {
 	// no route for small network.
 	if len(committee.Members) < ScaleThresholdForClustering {
 		return committee.Members, nil
 	}
-	return r.PeerSelector().SelectPeers(committee, msg, from)
+	return r.PeerSelector().SelectPeers(broadcaster, committee, msg, from)
 }
 
-func (r *Router) Forward(committee *types.Committee, m message.Msg, sender common.Address) {
+func (r *Router) Forward(broadcaster consensus.Broadcaster, committee *types.Committee, m message.Msg, sender common.Address) {
 	var recipients []types.CommitteeMember
-	recipients, err := r.Route(committee, m, sender)
+	recipients, err := r.Route(broadcaster, committee, m, sender)
 	if err != nil {
 		if !errors.Is(err, consensus.ErrFutureEpochMessage) {
 			log.Debug("No recipients for proposal", "error", err, "height", m.H())
@@ -538,7 +538,7 @@ type Selector struct {
 	*Router
 }
 
-func (s *Selector) SelectPeers(committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error) {
+func (s *Selector) SelectPeers(broadcaster consensus.Broadcaster, committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error) {
 
 	// around epoch rotation, resolveClusters() can be failed since router has its own epoch synchronization context,
 	// in this case, the caller should relay the message to all the members of input committee.
@@ -554,7 +554,7 @@ func (s *Selector) SelectPeers(committee *types.Committee, msg message.Msg, from
 		ownCluster := clusters.clusterContaining(from)
 
 		// select relayers from other clusters
-		receivers := clusters.selectK(VerticalRelayingRedundancy, num, ownCluster)
+		receivers := clusters.selectK(broadcaster, VerticalRelayingRedundancy, num, ownCluster)
 		numOfRelayers := len(receivers)
 
 		// send to local cluster nodes too.
@@ -618,7 +618,7 @@ func (s *Selector) SelectPeers(committee *types.Committee, msg message.Msg, from
 		}
 
 		// to add robustness, we also relay message to other clusters horizontally.
-		relayers := clusters.selectK(HorizontalRelayingRedundancy, num, ownCluster)
+		relayers := clusters.selectK(broadcaster, HorizontalRelayingRedundancy, num, ownCluster)
 		for _, addr := range relayers {
 			if member := committee.MemberByAddress(addr); member != nil && addr != from {
 				recipients = append(recipients, *member)

--- a/e2e_test/byzantine/raw_msg_fuzz_test.go
+++ b/e2e_test/byzantine/raw_msg_fuzz_test.go
@@ -65,7 +65,7 @@ func (fg *rawMSGFuzzer) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (fg *rawMSGFuzzer) AskSync(_ *types.Committee, _ uint64) {
+func (fg *rawMSGFuzzer) AskSync(_ *types.Committee, _ *message.LostSyncMsg) {
 	// do nothing
 }
 

--- a/e2e_test/clustering/network_clustering_test.go
+++ b/e2e_test/clustering/network_clustering_test.go
@@ -1,6 +1,7 @@
 package clustering
 
 import (
+	"github.com/autonity/autonity/consensus"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -114,7 +115,7 @@ func TestClusteringResetFNodes(t *testing.T) {
 // NoRelayingSelector is used for not to relay proposal in the network for Faulty nodes.
 type NoRelayingSelector struct{}
 
-func (r *NoRelayingSelector) SelectPeers(committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error) {
+func (r *NoRelayingSelector) SelectPeers(_ consensus.Broadcaster, committee *types.Committee, msg message.Msg, from common.Address) ([]types.CommitteeMember, error) {
 	// if not part of the committee return
 	if member := committee.MemberByAddress(from); member == nil {
 		return nil, nil

--- a/e2e_test/simulations/gossiper_test.go
+++ b/e2e_test/simulations/gossiper_test.go
@@ -74,7 +74,7 @@ func (cg *customGossiper) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (cg *customGossiper) AskSync(_ *types.Committee) {
+func (cg *customGossiper) AskSync(_ *types.Committee, _ *message.LostSyncMsg) {
 	// I disable the ask sync recovery mechanism, so that I can see if the gossip only is enough to keep the network live
 	log.Info("liveness lost, supposed to ask sync (but will not)")
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -291,7 +291,7 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 	eth.accountability = accountability.NewFaultDetector(
 		eth.blockchain,
 		eth.address,
-		evMux.Subscribe(events.MessageEvent{}, events.AccountabilityEvent{}, events.OldMessageEvent{}),
+		evMux.Subscribe(events.MessageEvent{}, events.AccountabilityEvent{}, events.OldMessageEvent{}, events.LostSyncEvent{}),
 		msgStore, eth.txPool, eth.APIBackend, nodeKey,
 		eth.blockchain.ProtocolContracts(),
 		eth.log)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -641,7 +641,7 @@ func (s *Ethereum) validatorController() {
 			for {
 				select {
 				case <-ticker.C:
-					if float64(s.consensusServer.PeerCount()) >= (float64(committee.Len()) * (2.0 / 3.0)) {
+					if float64(s.consensusServer.PeerCount()+1) >= (float64(committee.Len()) * (2.0 / 3.0)) {
 						mu.Lock()
 						if !wasValidating {
 							s.miner.Start()

--- a/eth/topology.go
+++ b/eth/topology.go
@@ -8,9 +8,9 @@ import (
 
 const (
 	// max degree allowed for network in the execution layer
-	MaxDegree = 25
+	MaxDegree = 50
 	// if the network size exceeds MaxGraphSize, we divide the network in smaller sub-network of size MaxGraphSize
-	MaxGraphSize = 64
+	MaxGraphSize = 512
 )
 
 type networkTopology struct {

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -53,7 +53,7 @@ var DefaultConfig = Config{
 	GraphQLVirtualHosts: []string{"localhost"},
 	ExecutionP2P: p2p.Config{
 		ListenAddr: DefaultETHPort,
-		MaxPeers:   50,
+		MaxPeers:   100,
 		NAT:        nat.Any(),
 	},
 	ConsensusP2P: p2p.Config{


### PR DESCRIPTION
This PR contains an improvement for the AskSync message and a few correction in routing:
1. Sync is base on a view exchange now to reduce msg flooding.
2. Handling of AskSync is decoupled from consensus engine to release the long period locking of the engine core.
3. Don't select dropped peer for msg relaying.
4. reconfig execution layers K degree for higher performance of msg relaying.
5. Fix in router.