### PR TITLE
Trigger ask sync improvement 2

### DIFF
--- a/accounts/abi/bind/backend_mock.go
+++ b/accounts/abi/bind/backend_mock.go
@@ -24,6 +24,7 @@ import (
 type MockContractCaller struct {
 	ctrl     *gomock.Controller
 	recorder *MockContractCallerMockRecorder
+	isgomock struct{}
 }
 
 // MockContractCallerMockRecorder is the mock recorder for MockContractCaller.
@@ -77,6 +78,7 @@ func (mr *MockContractCallerMockRecorder) CodeAt(ctx, contract, blockNumber any)
 type MockPendingContractCaller struct {
 	ctrl     *gomock.Controller
 	recorder *MockPendingContractCallerMockRecorder
+	isgomock struct{}
 }
 
 // MockPendingContractCallerMockRecorder is the mock recorder for MockPendingContractCaller.
@@ -130,6 +132,7 @@ func (mr *MockPendingContractCallerMockRecorder) PendingCodeAt(ctx, contract any
 type MockContractTransactor struct {
 	ctrl     *gomock.Controller
 	recorder *MockContractTransactorMockRecorder
+	isgomock struct{}
 }
 
 // MockContractTransactorMockRecorder is the mock recorder for MockContractTransactor.
@@ -257,6 +260,7 @@ func (mr *MockContractTransactorMockRecorder) SuggestGasTipCap(ctx any) *gomock.
 type MockContractFilterer struct {
 	ctrl     *gomock.Controller
 	recorder *MockContractFiltererMockRecorder
+	isgomock struct{}
 }
 
 // MockContractFiltererMockRecorder is the mock recorder for MockContractFilterer.
@@ -310,6 +314,7 @@ func (mr *MockContractFiltererMockRecorder) SubscribeFilterLogs(ctx, query, ch a
 type MockDeployBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockDeployBackendMockRecorder
+	isgomock struct{}
 }
 
 // MockDeployBackendMockRecorder is the mock recorder for MockDeployBackend.
@@ -363,6 +368,7 @@ func (mr *MockDeployBackendMockRecorder) TransactionReceipt(ctx, txHash any) *go
 type MockContractBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockContractBackendMockRecorder
+	isgomock struct{}
 }
 
 // MockContractBackendMockRecorder is the mock recorder for MockContractBackend.

--- a/consensus/consensus_mock.go
+++ b/consensus/consensus_mock.go
@@ -28,6 +28,7 @@ import (
 type MockChainHeaderReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockChainHeaderReaderMockRecorder
+	isgomock struct{}
 }
 
 // MockChainHeaderReaderMockRecorder is the mock recorder for MockChainHeaderReader.
@@ -150,6 +151,7 @@ func (mr *MockChainHeaderReaderMockRecorder) GetTd(hash, number any) *gomock.Cal
 type MockChainReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockChainReaderMockRecorder
+	isgomock struct{}
 }
 
 // MockChainReaderMockRecorder is the mock recorder for MockChainReader.
@@ -315,6 +317,7 @@ func (mr *MockChainReaderMockRecorder) GetTd(hash, number any) *gomock.Call {
 type MockEngine struct {
 	ctrl     *gomock.Controller
 	recorder *MockEngineMockRecorder
+	isgomock struct{}
 }
 
 // MockEngineMockRecorder is the mock recorder for MockEngine.
@@ -392,9 +395,9 @@ func (mr *MockEngineMockRecorder) Close() *gomock.Call {
 }
 
 // Finalize mocks base method.
-func (m *MockEngine) Finalize(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Receipt, *types.Epoch, *types.ContractsConfig, error) {
+func (m *MockEngine) Finalize(chain ChainReader, header *types.Header, arg2 *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Receipt, *types.Epoch, *types.ContractsConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Finalize", chain, header, state, txs, uncles, receipts)
+	ret := m.ctrl.Call(m, "Finalize", chain, header, arg2, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Receipt)
 	ret1, _ := ret[1].(*types.Epoch)
 	ret2, _ := ret[2].(*types.ContractsConfig)
@@ -403,15 +406,15 @@ func (m *MockEngine) Finalize(chain ChainReader, header *types.Header, state *st
 }
 
 // Finalize indicates an expected call of Finalize.
-func (mr *MockEngineMockRecorder) Finalize(chain, header, state, txs, uncles, receipts any) *gomock.Call {
+func (mr *MockEngineMockRecorder) Finalize(chain, header, arg2, txs, uncles, receipts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockEngine)(nil).Finalize), chain, header, state, txs, uncles, receipts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockEngine)(nil).Finalize), chain, header, arg2, txs, uncles, receipts)
 }
 
 // FinalizeAndAssemble mocks base method.
-func (m *MockEngine) FinalizeAndAssemble(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts *[]*types.Receipt) (*types.Block, *types.ContractsConfig, error) {
+func (m *MockEngine) FinalizeAndAssemble(chain ChainReader, header *types.Header, arg2 *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts *[]*types.Receipt) (*types.Block, *types.ContractsConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, state, txs, uncles, receipts)
+	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, arg2, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(*types.ContractsConfig)
 	ret2, _ := ret[2].(error)
@@ -419,9 +422,9 @@ func (m *MockEngine) FinalizeAndAssemble(chain ChainReader, header *types.Header
 }
 
 // FinalizeAndAssemble indicates an expected call of FinalizeAndAssemble.
-func (mr *MockEngineMockRecorder) FinalizeAndAssemble(chain, header, state, txs, uncles, receipts any) *gomock.Call {
+func (mr *MockEngineMockRecorder) FinalizeAndAssemble(chain, header, arg2, txs, uncles, receipts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockEngine)(nil).FinalizeAndAssemble), chain, header, state, txs, uncles, receipts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockEngine)(nil).FinalizeAndAssemble), chain, header, arg2, txs, uncles, receipts)
 }
 
 // Prepare mocks base method.
@@ -537,6 +540,7 @@ func (mr *MockEngineMockRecorder) VerifyUncles(chain, block any) *gomock.Call {
 type MockHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockHandlerMockRecorder
+	isgomock struct{}
 }
 
 // MockHandlerMockRecorder is the mock recorder for MockHandler.
@@ -613,6 +617,7 @@ func (mr *MockHandlerMockRecorder) SetEnqueuer(arg0 any) *gomock.Call {
 type MockPoW struct {
 	ctrl     *gomock.Controller
 	recorder *MockPoWMockRecorder
+	isgomock struct{}
 }
 
 // MockPoWMockRecorder is the mock recorder for MockPoW.
@@ -690,9 +695,9 @@ func (mr *MockPoWMockRecorder) Close() *gomock.Call {
 }
 
 // Finalize mocks base method.
-func (m *MockPoW) Finalize(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Receipt, *types.Epoch, *types.ContractsConfig, error) {
+func (m *MockPoW) Finalize(chain ChainReader, header *types.Header, arg2 *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Receipt, *types.Epoch, *types.ContractsConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Finalize", chain, header, state, txs, uncles, receipts)
+	ret := m.ctrl.Call(m, "Finalize", chain, header, arg2, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Receipt)
 	ret1, _ := ret[1].(*types.Epoch)
 	ret2, _ := ret[2].(*types.ContractsConfig)
@@ -701,15 +706,15 @@ func (m *MockPoW) Finalize(chain ChainReader, header *types.Header, state *state
 }
 
 // Finalize indicates an expected call of Finalize.
-func (mr *MockPoWMockRecorder) Finalize(chain, header, state, txs, uncles, receipts any) *gomock.Call {
+func (mr *MockPoWMockRecorder) Finalize(chain, header, arg2, txs, uncles, receipts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockPoW)(nil).Finalize), chain, header, state, txs, uncles, receipts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockPoW)(nil).Finalize), chain, header, arg2, txs, uncles, receipts)
 }
 
 // FinalizeAndAssemble mocks base method.
-func (m *MockPoW) FinalizeAndAssemble(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts *[]*types.Receipt) (*types.Block, *types.ContractsConfig, error) {
+func (m *MockPoW) FinalizeAndAssemble(chain ChainReader, header *types.Header, arg2 *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts *[]*types.Receipt) (*types.Block, *types.ContractsConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, state, txs, uncles, receipts)
+	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, arg2, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(*types.ContractsConfig)
 	ret2, _ := ret[2].(error)
@@ -717,9 +722,9 @@ func (m *MockPoW) FinalizeAndAssemble(chain ChainReader, header *types.Header, s
 }
 
 // FinalizeAndAssemble indicates an expected call of FinalizeAndAssemble.
-func (mr *MockPoWMockRecorder) FinalizeAndAssemble(chain, header, state, txs, uncles, receipts any) *gomock.Call {
+func (mr *MockPoWMockRecorder) FinalizeAndAssemble(chain, header, arg2, txs, uncles, receipts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockPoW)(nil).FinalizeAndAssemble), chain, header, state, txs, uncles, receipts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockPoW)(nil).FinalizeAndAssemble), chain, header, arg2, txs, uncles, receipts)
 }
 
 // Hashrate mocks base method.
@@ -849,6 +854,7 @@ func (mr *MockPoWMockRecorder) VerifyUncles(chain, block any) *gomock.Call {
 type MockBFT struct {
 	ctrl     *gomock.Controller
 	recorder *MockBFTMockRecorder
+	isgomock struct{}
 }
 
 // MockBFTMockRecorder is the mock recorder for MockBFT.
@@ -926,9 +932,9 @@ func (mr *MockBFTMockRecorder) Close() *gomock.Call {
 }
 
 // Finalize mocks base method.
-func (m *MockBFT) Finalize(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Receipt, *types.Epoch, *types.ContractsConfig, error) {
+func (m *MockBFT) Finalize(chain ChainReader, header *types.Header, arg2 *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Receipt, *types.Epoch, *types.ContractsConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Finalize", chain, header, state, txs, uncles, receipts)
+	ret := m.ctrl.Call(m, "Finalize", chain, header, arg2, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Receipt)
 	ret1, _ := ret[1].(*types.Epoch)
 	ret2, _ := ret[2].(*types.ContractsConfig)
@@ -937,15 +943,15 @@ func (m *MockBFT) Finalize(chain ChainReader, header *types.Header, state *state
 }
 
 // Finalize indicates an expected call of Finalize.
-func (mr *MockBFTMockRecorder) Finalize(chain, header, state, txs, uncles, receipts any) *gomock.Call {
+func (mr *MockBFTMockRecorder) Finalize(chain, header, arg2, txs, uncles, receipts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockBFT)(nil).Finalize), chain, header, state, txs, uncles, receipts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockBFT)(nil).Finalize), chain, header, arg2, txs, uncles, receipts)
 }
 
 // FinalizeAndAssemble mocks base method.
-func (m *MockBFT) FinalizeAndAssemble(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts *[]*types.Receipt) (*types.Block, *types.ContractsConfig, error) {
+func (m *MockBFT) FinalizeAndAssemble(chain ChainReader, header *types.Header, arg2 *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts *[]*types.Receipt) (*types.Block, *types.ContractsConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, state, txs, uncles, receipts)
+	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, arg2, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(*types.ContractsConfig)
 	ret2, _ := ret[2].(error)
@@ -953,9 +959,9 @@ func (m *MockBFT) FinalizeAndAssemble(chain ChainReader, header *types.Header, s
 }
 
 // FinalizeAndAssemble indicates an expected call of FinalizeAndAssemble.
-func (mr *MockBFTMockRecorder) FinalizeAndAssemble(chain, header, state, txs, uncles, receipts any) *gomock.Call {
+func (mr *MockBFTMockRecorder) FinalizeAndAssemble(chain, header, arg2, txs, uncles, receipts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockBFT)(nil).FinalizeAndAssemble), chain, header, state, txs, uncles, receipts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockBFT)(nil).FinalizeAndAssemble), chain, header, arg2, txs, uncles, receipts)
 }
 
 // Prepare mocks base method.
@@ -1085,6 +1091,7 @@ func (mr *MockBFTMockRecorder) VerifyUncles(chain, block any) *gomock.Call {
 type MockSyncer struct {
 	ctrl     *gomock.Controller
 	recorder *MockSyncerMockRecorder
+	isgomock struct{}
 }
 
 // MockSyncerMockRecorder is the mock recorder for MockSyncer.
@@ -1120,6 +1127,7 @@ func (mr *MockSyncerMockRecorder) SyncPeer(address any) *gomock.Call {
 type MockEnqueuer struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnqueuerMockRecorder
+	isgomock struct{}
 }
 
 // MockEnqueuerMockRecorder is the mock recorder for MockEnqueuer.
@@ -1155,6 +1163,7 @@ func (mr *MockEnqueuerMockRecorder) Enqueue(id, block any) *gomock.Call {
 type MockBroadcaster struct {
 	ctrl     *gomock.Controller
 	recorder *MockBroadcasterMockRecorder
+	isgomock struct{}
 }
 
 // MockBroadcasterMockRecorder is the mock recorder for MockBroadcaster.
@@ -1207,6 +1216,7 @@ func (mr *MockBroadcasterMockRecorder) FindPeers(arg0 any) *gomock.Call {
 type MockPeer struct {
 	ctrl     *gomock.Controller
 	recorder *MockPeerMockRecorder
+	isgomock struct{}
 }
 
 // MockPeerMockRecorder is the mock recorder for MockPeer.

--- a/consensus/tendermint/accountability/fault_detector_mock.go
+++ b/consensus/tendermint/accountability/fault_detector_mock.go
@@ -28,6 +28,7 @@ import (
 type MockChainContext struct {
 	ctrl     *gomock.Controller
 	recorder *MockChainContextMockRecorder
+	isgomock struct{}
 }
 
 // MockChainContextMockRecorder is the mock recorder for MockChainContext.

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -193,8 +193,8 @@ func (sb *Backend) Broadcast(committee *types.Committee, message message.Msg) {
 	})
 }
 
-func (sb *Backend) AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) {
-	sb.gossiper.AskSync(committee, syncMsg)
+func (sb *Backend) AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) error {
+	return sb.gossiper.AskSync(committee, syncMsg)
 }
 
 // Gossip implements tendermint.Backend.Gossip

--- a/consensus/tendermint/backend/backend_test.go
+++ b/consensus/tendermint/backend/backend_test.go
@@ -88,39 +88,41 @@ func makeSigner(key blst.SecretKey) message.Signer {
 func TestAskSync(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	// We are testing for a Quorum Q of peers to be asked for sync.
-	committee, _ := committeeAndBlsKeys(7) // N=7, F=2, Q=5
-	addresses := make([]common.Address, 0, committee.Len())
+
+	committeeSize := uint64(7)
+	committee, _ := committeeAndBlsKeys(int(committeeSize))
+	localAddress := committee.Members[0].Address
+
 	peers := make(map[common.Address]consensus.Peer)
 	counter := uint64(0)
-	for _, val := range committee.Members {
-		addresses = append(addresses, val.Address)
+	var remoteAddresses []common.Address
+	for _, val := range committee.Members[1:] {
 		mockedPeer := consensus.NewMockPeer(ctrl)
 		mockedPeer.EXPECT().Send(message.SyncNetworkMsg, gomock.Any()).Do(func(_, _ interface{}) {
 			atomic.AddUint64(&counter, 1)
-		}).MaxTimes(1)
+		}).Times(1)
+		remoteAddresses = append(remoteAddresses, val.Address)
 		peers[val.Address] = mockedPeer
 	}
 
-	m := make([]common.Address, 0)
-	m = append(m, addresses...)
 	knownMessages := fixsizecache.New[common.Hash, bool](499, 10, fixsizecache.HashKey[common.Hash])
 
 	broadcaster := consensus.NewMockBroadcaster(ctrl)
-	broadcaster.EXPECT().FindPeers(m).Return(peers)
+	broadcaster.EXPECT().FindPeers(remoteAddresses).Return(peers)
 	b := &Backend{
 		database:      rawdb.NewMemoryDatabase(),
 		knownMessages: knownMessages,
-		gossiper:      NewGossiper(knownMessages, common.Address{}, log.New(), make(chan struct{})),
+		gossiper:      NewGossiper(knownMessages, localAddress, log.New(), make(chan struct{})),
 		logger:        log.New("backend", "test", "id", 0),
 	}
 	b.SetBroadcaster(broadcaster)
 
 	askSyncMsg := &message.AskSyncMsg{}
-	b.AskSync(committee, askSyncMsg)
+	err := b.AskSync(committee, askSyncMsg)
+	require.NoError(t, err)
 	<-time.NewTimer(2 * time.Second).C
-	if atomic.LoadUint64(&counter) != 5 {
-		t.Fatalf("ask sync message transmission failure")
+	if val := atomic.LoadUint64(&counter); val != committeeSize-1 {
+		t.Fatalf("ask sync message transmission failure. wanted %d, got %d", committeeSize-1, val)
 	}
 }
 

--- a/consensus/tendermint/backend/gossiper.go
+++ b/consensus/tendermint/backend/gossiper.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"fmt"
+
 	"github.com/autonity/autonity/common"
 	"github.com/autonity/autonity/common/fixsizecache"
 	"github.com/autonity/autonity/consensus"
@@ -74,16 +76,16 @@ func (g *Gossiper) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (g *Gossiper) AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) {
+func (g *Gossiper) AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) error {
 	// bail out early if we don't have a broadcaster
 	if g.broadcaster == nil {
-		return
+		return fmt.Errorf("broadcaster not initialized")
 	}
 
 	encoded, err := rlp.EncodeToBytes(syncMsg)
 	if err != nil {
 		log.Error("Error encoding sync msg", "err", err)
-		return
+		panic("cannot encode sync message")
 	}
 
 	// send to everyone except ourselves
@@ -96,17 +98,18 @@ func (g *Gossiper) AskSync(committee *types.Committee, syncMsg *message.AskSyncM
 
 	// bail out if the local validator is the only one in the committee
 	if len(targets) == 0 {
-		return
+		return fmt.Errorf("no one to ask sync to")
 	}
 
 	ps := g.broadcaster.FindPeers(targets)
 	// bail out if we cannot find any peers
 	if len(ps) == 0 {
-		return
+		return fmt.Errorf("cannot find any peers")
 	}
 
 	for addr, p := range ps {
 		g.logger.Debug("Asking sync to", "addr", addr)
 		go p.Send(message.SyncNetworkMsg, encoded) //nolint
 	}
+	return nil
 }

--- a/consensus/tendermint/core/constants/error.go
+++ b/consensus/tendermint/core/constants/error.go
@@ -28,5 +28,6 @@ var (
 	// ErrMovedToNewRound is returned when timer could not be stopped in time
 	ErrMovedToNewRound = errors.New("timer expired and new round started")
 	// ErrRedundantVote is returned when we process a vote that doesn't bring any voting power contribution to Core
-	ErrRedundantVote = errors.New("vote did not bring any power contribution to Core")
+	// equivocated votes are considered as redundant
+	ErrRedundantVote = errors.New("vote did not bring any meaningful power contribution to Core")
 )

--- a/consensus/tendermint/core/constants/error.go
+++ b/consensus/tendermint/core/constants/error.go
@@ -27,4 +27,6 @@ var (
 	ErrNilPrecommitSent = errors.New("timer expired and nil precommit sent")
 	// ErrMovedToNewRound is returned when timer could not be stopped in time
 	ErrMovedToNewRound = errors.New("timer expired and new round started")
+	// ErrRedundantVote is returned when we process a vote that doesn't bring any voting power contribution to Core
+	ErrRedundantVote = errors.New("vote did not bring any power contribution to Core")
 )

--- a/consensus/tendermint/core/constants/error.go
+++ b/consensus/tendermint/core/constants/error.go
@@ -28,6 +28,7 @@ var (
 	// ErrMovedToNewRound is returned when timer could not be stopped in time
 	ErrMovedToNewRound = errors.New("timer expired and new round started")
 	// ErrRedundantVote is returned when we process a vote that doesn't bring any voting power contribution to Core
-	// equivocated votes are considered as redundant
+	// equivocated votes are considered as redundant, since they don't really signal any progress in the consensus instance
+	// they could eventually lead to block finalization, however it is not a guarantee
 	ErrRedundantVote = errors.New("vote did not bring any meaningful power contribution to Core")
 )

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -288,9 +288,15 @@ eventLoop:
 // - asking the network to send us the current consensus state if so
 func (c *Core) livenessTrackerLoop(ctx context.Context) {
 
-	// Ask for sync when the engine starts
-	syncMsg := c.createSyncMsg()
-	c.backend.AskSync(c.committee.Committee(), syncMsg)
+	// Ask for sync when the engine starts. Retry until sync succeeds
+	for {
+		err := c.backend.AskSync(c.committee.Committee(), c.createSyncMsg())
+		if err == nil {
+			break
+		}
+		c.logger.Warn("Failed to ask initial consensus sync, retrying...", "err", err)
+		time.Sleep(100 * time.Millisecond)
+	}
 
 	ticker := time.NewTicker(constants.AskSyncInterval)
 	defer ticker.Stop()
@@ -309,8 +315,11 @@ eventLoop:
 
 			// no liveness for more than currentSyncTimeout --> askSync to the other nodes
 			c.logger.Warn("⚠️ Consensus liveliness lost", "node", c.Address(), "height", c.Height(), "round", c.Round(), "step", c.Step())
-			syncMsg = c.createSyncMsg()
-			c.backend.AskSync(c.committee.Committee(), syncMsg)
+			err := c.backend.AskSync(c.committee.Committee(), c.createSyncMsg())
+			if err != nil {
+				c.logger.Warn("Failed to ask consensus sync", "err", err)
+				// will automatically retry at next iteration
+			}
 
 		case <-ctx.Done():
 			c.logger.Debug("livenessTrackerLoop is stopped", "event", ctx.Err())

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -224,7 +224,10 @@ eventLoop:
 				c.logger.Debug("Handling consensus backlog event")
 				if err := c.handleMsg(ctx, msg); err != nil {
 					c.logger.Debug("BacklogEvent message handling failed", "err", err)
-					continue
+					// we still want to gossip old round messages
+					if !errors.Is(err, constants.ErrOldRoundMessage) {
+						continue
+					}
 				}
 
 				// valid message, mark liveness time

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -287,15 +287,24 @@ eventLoop:
 // - tracking whether we are out of consensus sync
 // - asking the network to send us the current consensus state if so
 func (c *Core) livenessTrackerLoop(ctx context.Context) {
+	defer func() {
+		c.stopped <- struct{}{}
+	}()
 
-	// Ask for sync when the engine starts. Retry until sync succeeds
+	// Ask for sync when the engine starts. Retry until sync succeeds or we are stopped
 	for {
 		err := c.backend.AskSync(c.committee.Committee(), c.createSyncMsg())
 		if err == nil {
 			break
 		}
-		c.logger.Warn("Failed to ask initial consensus sync, retrying...", "err", err)
-		time.Sleep(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			c.logger.Debug("livenessTrackerLoop has been stopped before initial sync", "event", ctx.Err())
+			return
+		default:
+			c.logger.Warn("Failed to ask initial consensus sync, retrying...", "err", err)
+			time.Sleep(100 * time.Millisecond)
+		}
 	}
 
 	ticker := time.NewTicker(constants.AskSyncInterval)
@@ -326,8 +335,6 @@ eventLoop:
 			break eventLoop
 		}
 	}
-
-	c.stopped <- struct{}{}
 }
 
 // SendEvent sends event to mux

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -194,7 +194,7 @@ eventLoop:
 				}
 
 				// valid message, mark liveness time unless it was redundant
-				if err == nil || !errors.Is(err, constants.ErrRedundantVote) {
+				if !errors.Is(err, constants.ErrRedundantVote) {
 					c.syncState.setLastLivenessTime(time.Now())
 				}
 
@@ -237,7 +237,7 @@ eventLoop:
 				}
 
 				// valid message, mark liveness time unless it was redundant
-				if err == nil || !errors.Is(err, constants.ErrRedundantVote) {
+				if !errors.Is(err, constants.ErrRedundantVote) {
 					c.syncState.setLastLivenessTime(time.Now())
 				}
 

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -91,6 +91,8 @@ func shouldDisconnectSender(err error) bool {
 		fallthrough
 	case errors.Is(err, consensus.ErrPrunedAncestor):
 		fallthrough
+	case errors.Is(err, constants.ErrRedundantVote):
+		fallthrough
 	case errors.Is(err, constants.ErrAlreadyHaveProposal):
 		return false
 	default:
@@ -178,20 +180,23 @@ eventLoop:
 					hadQuorum = c.quorumFor(msg.Code(), msg.R(), msg.Value())
 				}
 
-				if err := c.handleMsg(ctx, msg); err != nil {
+				var err error
+				if err = c.handleMsg(ctx, msg); err != nil {
 					c.logger.Debug("MessageEvent payload failed", "err", err)
 					// filter errors which needs remote peer disconnection
 					if shouldDisconnectSender(err) {
 						tryDisconnect(e.ErrCh, err)
 					}
-					// we still want to gossip old round messages
-					if !errors.Is(err, constants.ErrOldRoundMessage) {
+					// we still want to gossip old round messages and redundant votes
+					if !errors.Is(err, constants.ErrOldRoundMessage) && !errors.Is(err, constants.ErrRedundantVote) {
 						break
 					}
 				}
 
-				// valid message, mark liveness time
-				c.syncState.setLastLivenessTime(time.Now())
+				// valid message, mark liveness time unless it was redundant
+				if err == nil || !errors.Is(err, constants.ErrRedundantVote) {
+					c.syncState.setLastLivenessTime(time.Now())
+				}
 
 				if !c.noGossip {
 					if !hadQuorum {
@@ -222,16 +227,19 @@ eventLoop:
 				}
 
 				c.logger.Debug("Handling consensus backlog event")
-				if err := c.handleMsg(ctx, msg); err != nil {
+				var err error
+				if err = c.handleMsg(ctx, msg); err != nil {
 					c.logger.Debug("BacklogEvent message handling failed", "err", err)
-					// we still want to gossip old round messages
-					if !errors.Is(err, constants.ErrOldRoundMessage) {
+					// we still want to gossip old round messages and redundant votes
+					if !errors.Is(err, constants.ErrOldRoundMessage) && !errors.Is(err, constants.ErrRedundantVote) {
 						continue
 					}
 				}
 
-				// valid message, mark liveness time
-				c.syncState.setLastLivenessTime(time.Now())
+				// valid message, mark liveness time unless it was redundant
+				if err == nil || !errors.Is(err, constants.ErrRedundantVote) {
+					c.syncState.setLastLivenessTime(time.Now())
+				}
 
 				if !c.noGossip {
 					if !hadQuorum {
@@ -428,4 +436,11 @@ func tryDisconnect(errorCh chan<- error, err error) {
 	case errorCh <- err:
 	default: // do nothing
 	}
+}
+
+func isRedundant(wasUseful bool) error {
+	if wasUseful {
+		return nil
+	}
+	return constants.ErrRedundantVote
 }

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -438,8 +438,8 @@ func tryDisconnect(errorCh chan<- error, err error) {
 	}
 }
 
-func isRedundant(wasUseful bool) error {
-	if wasUseful {
+func redundancyError(didContribute bool) error {
+	if didContribute {
 		return nil
 	}
 	return constants.ErrRedundantVote

--- a/consensus/tendermint/core/interfaces/broadcaster_mock.go
+++ b/consensus/tendermint/core/interfaces/broadcaster_mock.go
@@ -20,6 +20,7 @@ import (
 type MockBroadcaster struct {
 	ctrl     *gomock.Controller
 	recorder *MockBroadcasterMockRecorder
+	isgomock struct{}
 }
 
 // MockBroadcasterMockRecorder is the mock recorder for MockBroadcaster.

--- a/consensus/tendermint/core/interfaces/core_backend.go
+++ b/consensus/tendermint/core/interfaces/core_backend.go
@@ -23,7 +23,7 @@ type Backend interface {
 
 	AddSeal(block *types.Block) (*types.Block, error)
 
-	AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg)
+	AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) error
 
 	// Broadcast sends a message to all validators (include self)
 	Broadcast(committee *types.Committee, message message.Msg)

--- a/consensus/tendermint/core/interfaces/core_backend_mock.go
+++ b/consensus/tendermint/core/interfaces/core_backend_mock.go
@@ -32,6 +32,7 @@ import (
 type MockBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackendMockRecorder
+	isgomock struct{}
 }
 
 // MockBackendMockRecorder is the mock recorder for MockBackend.
@@ -81,9 +82,11 @@ func (mr *MockBackendMockRecorder) Address() *gomock.Call {
 }
 
 // AskSync mocks base method.
-func (m *MockBackend) AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) {
+func (m *MockBackend) AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AskSync", committee, syncMsg)
+	ret := m.ctrl.Call(m, "AskSync", committee, syncMsg)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AskSync indicates an expected call of AskSync.
@@ -107,15 +110,15 @@ func (mr *MockBackendMockRecorder) BlockChain() *gomock.Call {
 }
 
 // Broadcast mocks base method.
-func (m *MockBackend) Broadcast(committee *types.Committee, message message.Msg) {
+func (m *MockBackend) Broadcast(committee *types.Committee, arg1 message.Msg) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Broadcast", committee, message)
+	m.ctrl.Call(m, "Broadcast", committee, arg1)
 }
 
 // Broadcast indicates an expected call of Broadcast.
-func (mr *MockBackendMockRecorder) Broadcast(committee, message any) *gomock.Call {
+func (mr *MockBackendMockRecorder) Broadcast(committee, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Broadcast", reflect.TypeOf((*MockBackend)(nil).Broadcast), committee, message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Broadcast", reflect.TypeOf((*MockBackend)(nil).Broadcast), committee, arg1)
 }
 
 // Commit mocks base method.
@@ -176,15 +179,15 @@ func (mr *MockBackendMockRecorder) GetContractABI() *gomock.Call {
 }
 
 // Gossip mocks base method.
-func (m *MockBackend) Gossip(committee *types.Committee, message message.Msg) {
+func (m *MockBackend) Gossip(committee *types.Committee, arg1 message.Msg) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Gossip", committee, message)
+	m.ctrl.Call(m, "Gossip", committee, arg1)
 }
 
 // Gossip indicates an expected call of Gossip.
-func (mr *MockBackendMockRecorder) Gossip(committee, message any) *gomock.Call {
+func (mr *MockBackendMockRecorder) Gossip(committee, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gossip", reflect.TypeOf((*MockBackend)(nil).Gossip), committee, message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gossip", reflect.TypeOf((*MockBackend)(nil).Gossip), committee, arg1)
 }
 
 // Gossiper mocks base method.
@@ -386,10 +389,10 @@ func (mr *MockBackendMockRecorder) Sign(hash any) *gomock.Call {
 }
 
 // Subscribe mocks base method.
-func (m *MockBackend) Subscribe(types ...any) *event.TypeMuxSubscription {
+func (m *MockBackend) Subscribe(arg0 ...any) *event.TypeMuxSubscription {
 	m.ctrl.T.Helper()
 	varargs := []any{}
-	for _, a := range types {
+	for _, a := range arg0 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Subscribe", varargs...)
@@ -398,9 +401,9 @@ func (m *MockBackend) Subscribe(types ...any) *event.TypeMuxSubscription {
 }
 
 // Subscribe indicates an expected call of Subscribe.
-func (mr *MockBackendMockRecorder) Subscribe(types ...any) *gomock.Call {
+func (mr *MockBackendMockRecorder) Subscribe(arg0 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockBackend)(nil).Subscribe), types...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockBackend)(nil).Subscribe), arg0...)
 }
 
 // VerifyProposal mocks base method.
@@ -422,6 +425,7 @@ func (mr *MockBackendMockRecorder) VerifyProposal(arg0 any) *gomock.Call {
 type MockCore struct {
 	ctrl     *gomock.Controller
 	recorder *MockCoreMockRecorder
+	isgomock struct{}
 }
 
 // MockCoreMockRecorder is the mock recorder for MockCore.
@@ -623,6 +627,7 @@ func (mr *MockCoreMockRecorder) VotesPowerFor(h, r, code, v any) *gomock.Call {
 type MockEventDispatcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockEventDispatcherMockRecorder
+	isgomock struct{}
 }
 
 // MockEventDispatcherMockRecorder is the mock recorder for MockEventDispatcher.

--- a/consensus/tendermint/core/interfaces/gossiper.go
+++ b/consensus/tendermint/core/interfaces/gossiper.go
@@ -10,7 +10,7 @@ import (
 
 type Gossiper interface {
 	Gossip(committee *types.Committee, message message.Msg)
-	AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg)
+	AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) error
 	SetBroadcaster(broadcaster consensus.Broadcaster)
 	Broadcaster() consensus.Broadcaster
 	KnownMessages() *fixsizecache.Cache[common.Hash, bool]

--- a/consensus/tendermint/core/interfaces/gossiper_mock.go
+++ b/consensus/tendermint/core/interfaces/gossiper_mock.go
@@ -24,6 +24,7 @@ import (
 type MockGossiper struct {
 	ctrl     *gomock.Controller
 	recorder *MockGossiperMockRecorder
+	isgomock struct{}
 }
 
 // MockGossiperMockRecorder is the mock recorder for MockGossiper.
@@ -58,15 +59,17 @@ func (mr *MockGossiperMockRecorder) Address() *gomock.Call {
 }
 
 // AskSync mocks base method.
-func (m *MockGossiper) AskSync(committee *types.Committee, askSync *message.AskSyncMsg) {
+func (m *MockGossiper) AskSync(committee *types.Committee, syncMsg *message.AskSyncMsg) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AskSync", committee, askSync)
+	ret := m.ctrl.Call(m, "AskSync", committee, syncMsg)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AskSync indicates an expected call of AskSync.
-func (mr *MockGossiperMockRecorder) AskSync(committee, askSync any) *gomock.Call {
+func (mr *MockGossiperMockRecorder) AskSync(committee, syncMsg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskSync", reflect.TypeOf((*MockGossiper)(nil).AskSync), committee, askSync)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskSync", reflect.TypeOf((*MockGossiper)(nil).AskSync), committee, syncMsg)
 }
 
 // Broadcaster mocks base method.
@@ -84,15 +87,15 @@ func (mr *MockGossiperMockRecorder) Broadcaster() *gomock.Call {
 }
 
 // Gossip mocks base method.
-func (m *MockGossiper) Gossip(committee *types.Committee, message message.Msg) {
+func (m *MockGossiper) Gossip(committee *types.Committee, arg1 message.Msg) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Gossip", committee, message)
+	m.ctrl.Call(m, "Gossip", committee, arg1)
 }
 
 // Gossip indicates an expected call of Gossip.
-func (mr *MockGossiperMockRecorder) Gossip(committee, message any) *gomock.Call {
+func (mr *MockGossiperMockRecorder) Gossip(committee, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gossip", reflect.TypeOf((*MockGossiper)(nil).Gossip), committee, message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gossip", reflect.TypeOf((*MockGossiper)(nil).Gossip), committee, arg1)
 }
 
 // KnownMessages mocks base method.

--- a/consensus/tendermint/core/message/power.go
+++ b/consensus/tendermint/core/message/power.go
@@ -15,7 +15,7 @@ func Contribution(aggregatorSigners *big.Int, coreSigners *big.Int) *big.Int {
 	return contribution
 }
 
-// returns whether the new signer increased the power or was useless
+// returns whether the new signer increased the power or was redundant
 func (p *AggregatedPower) Set(index int, power *big.Int) bool {
 	if p.signers.Bit(index) == 1 {
 		return false // no power increase, the signer was already included

--- a/consensus/tendermint/core/message/power.go
+++ b/consensus/tendermint/core/message/power.go
@@ -15,13 +15,15 @@ func Contribution(aggregatorSigners *big.Int, coreSigners *big.Int) *big.Int {
 	return contribution
 }
 
-func (p *AggregatedPower) Set(index int, power *big.Int) {
+// returns whether the new signer increased the power or was useless
+func (p *AggregatedPower) Set(index int, power *big.Int) bool {
 	if p.signers.Bit(index) == 1 {
-		return
+		return false // no power increase, the signer was already included
 	}
 
 	p.signers.SetBit(p.signers, index, 1)
 	p.power.Add(p.power, power)
+	return true
 }
 
 func (p *AggregatedPower) Power() *big.Int {

--- a/consensus/tendermint/core/message/power_test.go
+++ b/consensus/tendermint/core/message/power_test.go
@@ -99,3 +99,16 @@ func TestContribution(t *testing.T) {
 	require.Equal(t, uint(0), contribution.Bit(1000000001))
 	require.Equal(t, 0, contribution.Cmp(common.Big0))
 }
+
+func TestSetReturnValue(t *testing.T) {
+	p := NewAggregatedPower()
+
+	require.True(t, p.Set(0, common.Big1))
+	require.True(t, p.Set(1, common.Big4))
+
+	require.False(t, p.Set(0, common.Big5))
+	require.False(t, p.Set(1, common.Big3))
+
+	require.True(t, p.Set(3, common.Big4))
+
+}

--- a/consensus/tendermint/core/message/round_messages.go
+++ b/consensus/tendermint/core/message/round_messages.go
@@ -148,15 +148,17 @@ func (s *RoundMessages) PrecommitsTotalAggregatedPower() *AggregatedPower {
 	return s.precommits.TotalPower()
 }
 
-func (s *RoundMessages) AddPrevote(prevote *Prevote) {
+// returns whether the new vote brought some power contribution or the vote was useless
+func (s *RoundMessages) AddPrevote(prevote *Prevote) bool {
 	s.Lock()
 	defer s.Unlock()
-	s.prevotes.Add(prevote)
+	wasUseful := s.prevotes.Add(prevote)
 	// update round power cache
 	for index, power := range prevote.Signers().Powers() {
-		s.power.Set(index, power)
+		didContribute := s.power.Set(index, power)
+		wasUseful = wasUseful || didContribute
 	}
-
+	return wasUseful
 }
 
 func (s *RoundMessages) AllPrevotes() []Msg {
@@ -167,14 +169,17 @@ func (s *RoundMessages) AllPrecommits() []Msg {
 	return s.precommits.Messages()
 }
 
-func (s *RoundMessages) AddPrecommit(precommit *Precommit) {
+// returns whether the new vote brought some power contribution or the vote was useless
+func (s *RoundMessages) AddPrecommit(precommit *Precommit) bool {
 	s.Lock()
 	defer s.Unlock()
-	s.precommits.Add(precommit)
+	wasUseful := s.precommits.Add(precommit)
 	// update round power cache
 	for index, power := range precommit.Signers().Powers() {
-		s.power.Set(index, power)
+		didContribute := s.power.Set(index, power)
+		wasUseful = wasUseful || didContribute
 	}
+	return wasUseful
 }
 
 // used to gossip quorum of prevotes

--- a/consensus/tendermint/core/message/round_messages.go
+++ b/consensus/tendermint/core/message/round_messages.go
@@ -148,17 +148,16 @@ func (s *RoundMessages) PrecommitsTotalAggregatedPower() *AggregatedPower {
 	return s.precommits.TotalPower()
 }
 
-// returns whether the new vote brought some power contribution or the vote was useless
+// returns whether the new vote brought some power contribution or the vote was redundant
 func (s *RoundMessages) AddPrevote(prevote *Prevote) bool {
 	s.Lock()
 	defer s.Unlock()
-	wasUseful := s.prevotes.Add(prevote)
+	voteContributed := s.prevotes.Add(prevote)
 	// update round power cache
 	for index, power := range prevote.Signers().Powers() {
-		didContribute := s.power.Set(index, power)
-		wasUseful = wasUseful || didContribute
+		s.power.Set(index, power)
 	}
-	return wasUseful
+	return voteContributed
 }
 
 func (s *RoundMessages) AllPrevotes() []Msg {
@@ -169,17 +168,16 @@ func (s *RoundMessages) AllPrecommits() []Msg {
 	return s.precommits.Messages()
 }
 
-// returns whether the new vote brought some power contribution or the vote was useless
+// returns whether the new vote brought some power contribution or the vote was redundant
 func (s *RoundMessages) AddPrecommit(precommit *Precommit) bool {
 	s.Lock()
 	defer s.Unlock()
-	wasUseful := s.precommits.Add(precommit)
+	voteContributed := s.precommits.Add(precommit)
 	// update round power cache
 	for index, power := range precommit.Signers().Powers() {
-		didContribute := s.power.Set(index, power)
-		wasUseful = wasUseful || didContribute
+		s.power.Set(index, power)
 	}
-	return wasUseful
+	return voteContributed
 }
 
 // used to gossip quorum of prevotes

--- a/consensus/tendermint/core/message/set.go
+++ b/consensus/tendermint/core/message/set.go
@@ -30,13 +30,14 @@ func NewSet() *Set {
 	}
 }
 
-// returns whether the new signers increased the power or the vote was useless
+// returns whether the new signers increased the power or the vote was redundant
 func (s *Set) Add(vote Vote) bool {
 	s.Lock()
 	defer s.Unlock()
 
 	// will be set to true if the vote brings an increase in voting power in Core
-	wasUseful := false
+	// equivocated votes are considered redundant
+	voteContributed := false
 
 	value := vote.Value()
 	previousVotes, ok := s.votes[value]
@@ -47,16 +48,15 @@ func (s *Set) Add(vote Vote) bool {
 
 	// update total power and power for value
 	for index, power := range vote.Signers().Powers() {
-		didContribute := s.totalPower.Set(index, power)
-		wasUseful = wasUseful || didContribute
-		didContribute = s.powers[value].Set(index, power)
-		wasUseful = wasUseful || didContribute
+		signerContributed := s.totalPower.Set(index, power)
+		voteContributed = voteContributed || signerContributed
+		s.powers[value].Set(index, power)
 	}
 
 	// check if we are adding the first vote
 	if len(previousVotes) == 0 {
 		s.votes[value][0] = vote
-		return wasUseful
+		return voteContributed
 	}
 
 	// if not first vote, aggregate previous votes and new vote
@@ -76,7 +76,7 @@ func (s *Set) Add(vote Vote) bool {
 	default:
 		panic("Trying to add a vote that is not Prevote nor Precommit")
 	}
-	return wasUseful
+	return voteContributed
 }
 
 func (s *Set) Messages() []Msg {

--- a/consensus/tendermint/core/message/set.go
+++ b/consensus/tendermint/core/message/set.go
@@ -30,9 +30,13 @@ func NewSet() *Set {
 	}
 }
 
-func (s *Set) Add(vote Vote) {
+// returns whether the new signers increased the power or the vote was useless
+func (s *Set) Add(vote Vote) bool {
 	s.Lock()
 	defer s.Unlock()
+
+	// will be set to true if the vote brings an increase in voting power in Core
+	wasUseful := false
 
 	value := vote.Value()
 	previousVotes, ok := s.votes[value]
@@ -43,14 +47,16 @@ func (s *Set) Add(vote Vote) {
 
 	// update total power and power for value
 	for index, power := range vote.Signers().Powers() {
-		s.totalPower.Set(index, power)
-		s.powers[value].Set(index, power)
+		didContribute := s.totalPower.Set(index, power)
+		wasUseful = wasUseful || didContribute
+		didContribute = s.powers[value].Set(index, power)
+		wasUseful = wasUseful || didContribute
 	}
 
 	// check if we are adding the first vote
 	if len(previousVotes) == 0 {
 		s.votes[value][0] = vote
-		return
+		return wasUseful
 	}
 
 	// if not first vote, aggregate previous votes and new vote
@@ -70,6 +76,7 @@ func (s *Set) Add(vote Vote) {
 	default:
 		panic("Trying to add a vote that is not Prevote nor Precommit")
 	}
+	return wasUseful
 }
 
 func (s *Set) Messages() []Msg {

--- a/consensus/tendermint/core/message/set_test.go
+++ b/consensus/tendermint/core/message/set_test.go
@@ -230,3 +230,31 @@ func TestMessageSetValues(t *testing.T) {
 		}
 	})
 }
+
+func TestAddReturnValue(t *testing.T) {
+	r := int64(1)
+	h := uint64(1)
+	csize := testCommittee.Len()
+
+	ms := NewSet()
+
+	vote := NewPrevote(r, h, blockHash, defaultSigner, makeCommitteeMember(1, 0), csize)
+	require.True(t, ms.Add(vote))
+	require.False(t, ms.Add(vote))
+
+	equivocatedVote := NewPrevote(r, h, blockHash2, defaultSigner, makeCommitteeMember(1, 0), csize)
+	require.True(t, ms.Add(equivocatedVote))
+
+	// add vote from another validator
+	vote2 := NewPrevote(r, h, blockHash, defaultSigner, makeCommitteeMember(2, 1), csize)
+	require.True(t, ms.Add(vote2))
+
+	// add another aggregate
+	aggregate := AggregatePrevotesSimple([]Vote{NewPrevote(r, h, blockHash, defaultSigner, makeCommitteeMember(1, 0), csize), NewPrevote(r, h, blockHash, defaultSigner, makeCommitteeMember(2, 2), csize)})
+	require.True(t, ms.Add(aggregate[0]))
+
+	// redundant vote
+	vote3 := NewPrevote(r, h, blockHash, defaultSigner, makeCommitteeMember(2, 2), csize)
+	require.False(t, ms.Add(vote3))
+
+}

--- a/consensus/tendermint/core/message/set_test.go
+++ b/consensus/tendermint/core/message/set_test.go
@@ -243,7 +243,7 @@ func TestAddReturnValue(t *testing.T) {
 	require.False(t, ms.Add(vote))
 
 	equivocatedVote := NewPrevote(r, h, blockHash2, defaultSigner, makeCommitteeMember(1, 0), csize)
-	require.True(t, ms.Add(equivocatedVote))
+	require.False(t, ms.Add(equivocatedVote))
 
 	// add vote from another validator
 	vote2 := NewPrevote(r, h, blockHash, defaultSigner, makeCommitteeMember(2, 1), csize)

--- a/consensus/tendermint/core/precommit.go
+++ b/consensus/tendermint/core/precommit.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"time"
 
@@ -60,28 +61,28 @@ func (c *Precommiter) HandlePrecommit(ctx context.Context, precommit *message.Pr
 		// We are receiving a precommit for an old round. We need to check if we have now a quorum
 		// in this old round.
 		roundMessages := c.messages.GetOrCreate(precommit.R())
-		roundMessages.AddPrecommit(precommit)
+		wasUseful := roundMessages.AddPrecommit(precommit)
 		c.SendEvent(events.NewPowerChangeEvent(message.PrecommitCode, c.Height().Uint64(), c.Round(), precommit.Value()))
 
 		oldRoundProposal := roundMessages.Proposal()
 		if oldRoundProposal == nil {
-			return constants.ErrOldRoundMessage
+			return errors.Join(constants.ErrOldRoundMessage, isRedundant(wasUseful))
 		}
 
 		// Line 49 in Algorithm 1 of The latest gossip on BFT consensus
 		_ = c.quorumPrecommitsCheck(ctx, oldRoundProposal, roundMessages.IsProposalVerified())
-		return constants.ErrOldRoundMessage
+		return errors.Join(constants.ErrOldRoundMessage, isRedundant(wasUseful))
 	}
 
 	// Precommit if for current round from here
 	// We don't care about which step we are in to accept a precommit, since it has the highest importance
 
-	c.curRoundMessages.AddPrecommit(precommit)
+	wasUseful := c.curRoundMessages.AddPrecommit(precommit)
 	c.SendEvent(events.NewPowerChangeEvent(message.PrecommitCode, c.Height().Uint64(), c.Round(), precommit.Value()))
 	c.LogPrecommitMessageEvent("MessageEvent(Precommit): Received", precommit)
 
 	c.currentPrecommitChecks(ctx)
-	return nil
+	return isRedundant(wasUseful)
 }
 
 func (c *Precommiter) HandleCommit(ctx context.Context) {

--- a/consensus/tendermint/core/precommit.go
+++ b/consensus/tendermint/core/precommit.go
@@ -62,6 +62,7 @@ func (c *Precommiter) HandlePrecommit(ctx context.Context, precommit *message.Pr
 		// in this old round.
 		roundMessages := c.messages.GetOrCreate(precommit.R())
 		precommitContributed := roundMessages.AddPrecommit(precommit)
+		// note even if the vote is redundant, it might still cause a power change in case of equivocation
 		c.SendEvent(events.NewPowerChangeEvent(message.PrecommitCode, c.Height().Uint64(), c.Round(), precommit.Value()))
 
 		oldRoundProposal := roundMessages.Proposal()
@@ -78,6 +79,7 @@ func (c *Precommiter) HandlePrecommit(ctx context.Context, precommit *message.Pr
 	// We don't care about which step we are in to accept a precommit, since it has the highest importance
 
 	precommitContributed := c.curRoundMessages.AddPrecommit(precommit)
+	// note even if the vote is redundant, it might still cause a power change in case of equivocation
 	c.SendEvent(events.NewPowerChangeEvent(message.PrecommitCode, c.Height().Uint64(), c.Round(), precommit.Value()))
 	c.LogPrecommitMessageEvent("MessageEvent(Precommit): Received", precommit)
 

--- a/consensus/tendermint/core/precommit.go
+++ b/consensus/tendermint/core/precommit.go
@@ -61,28 +61,28 @@ func (c *Precommiter) HandlePrecommit(ctx context.Context, precommit *message.Pr
 		// We are receiving a precommit for an old round. We need to check if we have now a quorum
 		// in this old round.
 		roundMessages := c.messages.GetOrCreate(precommit.R())
-		wasUseful := roundMessages.AddPrecommit(precommit)
+		precommitContributed := roundMessages.AddPrecommit(precommit)
 		c.SendEvent(events.NewPowerChangeEvent(message.PrecommitCode, c.Height().Uint64(), c.Round(), precommit.Value()))
 
 		oldRoundProposal := roundMessages.Proposal()
 		if oldRoundProposal == nil {
-			return errors.Join(constants.ErrOldRoundMessage, isRedundant(wasUseful))
+			return errors.Join(constants.ErrOldRoundMessage, redundancyError(precommitContributed))
 		}
 
 		// Line 49 in Algorithm 1 of The latest gossip on BFT consensus
 		_ = c.quorumPrecommitsCheck(ctx, oldRoundProposal, roundMessages.IsProposalVerified())
-		return errors.Join(constants.ErrOldRoundMessage, isRedundant(wasUseful))
+		return errors.Join(constants.ErrOldRoundMessage, redundancyError(precommitContributed))
 	}
 
 	// Precommit if for current round from here
 	// We don't care about which step we are in to accept a precommit, since it has the highest importance
 
-	wasUseful := c.curRoundMessages.AddPrecommit(precommit)
+	precommitContributed := c.curRoundMessages.AddPrecommit(precommit)
 	c.SendEvent(events.NewPowerChangeEvent(message.PrecommitCode, c.Height().Uint64(), c.Round(), precommit.Value()))
 	c.LogPrecommitMessageEvent("MessageEvent(Precommit): Received", precommit)
 
 	c.currentPrecommitChecks(ctx)
-	return isRedundant(wasUseful)
+	return redundancyError(precommitContributed)
 }
 
 func (c *Precommiter) HandleCommit(ctx context.Context) {

--- a/consensus/tendermint/core/prevote.go
+++ b/consensus/tendermint/core/prevote.go
@@ -55,32 +55,32 @@ func (c *Prevoter) HandlePrevote(ctx context.Context, prevote *message.Prevote) 
 	if prevote.R() < c.Round() {
 		// We only process old rounds while future rounds messages are pushed on to the backlog
 		oldRoundMessages := c.messages.GetOrCreate(prevote.R())
-		wasUseful := oldRoundMessages.AddPrevote(prevote)
+		prevoteContributed := oldRoundMessages.AddPrevote(prevote)
 		c.SendEvent(events.NewPowerChangeEvent(message.PrevoteCode, c.Height().Uint64(), c.Round(), prevote.Value()))
 
 		// Proposal would be nil if node haven't received the proposal yet.
 		proposal := c.curRoundMessages.Proposal()
 		if proposal == nil {
-			return errors.Join(constants.ErrOldRoundMessage, isRedundant(wasUseful))
+			return errors.Join(constants.ErrOldRoundMessage, redundancyError(prevoteContributed))
 		}
 
 		// Line 28 in Algorithm 1 of The latest gossip on BFT consensus.
 		// check if we have quorum prevotes on vr
 		c.oldProposalCheck(ctx, proposal)
-		return errors.Join(constants.ErrOldRoundMessage, isRedundant(wasUseful))
+		return errors.Join(constants.ErrOldRoundMessage, redundancyError(prevoteContributed))
 	}
 
 	// After checking the message we know it is from the same height and round, so we should store it even if
 	// c.curRoundMessages.Step() < prevote. The propose Timeout which is started at the beginning of the round
 	// will update the step to at least prevote and when it handle its on preVote(nil), then it will also have
 	// votes from other nodes.
-	wasUseful := c.curRoundMessages.AddPrevote(prevote)
+	prevoteContributed := c.curRoundMessages.AddPrevote(prevote)
 	c.SendEvent(events.NewPowerChangeEvent(message.PrevoteCode, c.Height().Uint64(), c.Round(), prevote.Value()))
 
 	c.LogPrevoteMessageEvent("MessageEvent(Prevote): Received", prevote)
 	// check upon conditions for current round proposal
 	c.currentPrevoteChecks(ctx)
-	return isRedundant(wasUseful)
+	return redundancyError(prevoteContributed)
 }
 
 func (c *Prevoter) LogPrevoteMessageEvent(message string, prevote *message.Prevote) {

--- a/consensus/tendermint/core/prevote.go
+++ b/consensus/tendermint/core/prevote.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"time"
 
@@ -54,32 +55,32 @@ func (c *Prevoter) HandlePrevote(ctx context.Context, prevote *message.Prevote) 
 	if prevote.R() < c.Round() {
 		// We only process old rounds while future rounds messages are pushed on to the backlog
 		oldRoundMessages := c.messages.GetOrCreate(prevote.R())
-		oldRoundMessages.AddPrevote(prevote)
+		wasUseful := oldRoundMessages.AddPrevote(prevote)
 		c.SendEvent(events.NewPowerChangeEvent(message.PrevoteCode, c.Height().Uint64(), c.Round(), prevote.Value()))
 
 		// Proposal would be nil if node haven't received the proposal yet.
 		proposal := c.curRoundMessages.Proposal()
 		if proposal == nil {
-			return constants.ErrOldRoundMessage
+			return errors.Join(constants.ErrOldRoundMessage, isRedundant(wasUseful))
 		}
 
 		// Line 28 in Algorithm 1 of The latest gossip on BFT consensus.
 		// check if we have quorum prevotes on vr
 		c.oldProposalCheck(ctx, proposal)
-		return constants.ErrOldRoundMessage
+		return errors.Join(constants.ErrOldRoundMessage, isRedundant(wasUseful))
 	}
 
 	// After checking the message we know it is from the same height and round, so we should store it even if
 	// c.curRoundMessages.Step() < prevote. The propose Timeout which is started at the beginning of the round
 	// will update the step to at least prevote and when it handle its on preVote(nil), then it will also have
 	// votes from other nodes.
-	c.curRoundMessages.AddPrevote(prevote)
+	wasUseful := c.curRoundMessages.AddPrevote(prevote)
 	c.SendEvent(events.NewPowerChangeEvent(message.PrevoteCode, c.Height().Uint64(), c.Round(), prevote.Value()))
 
 	c.LogPrevoteMessageEvent("MessageEvent(Prevote): Received", prevote)
 	// check upon conditions for current round proposal
 	c.currentPrevoteChecks(ctx)
-	return nil
+	return isRedundant(wasUseful)
 }
 
 func (c *Prevoter) LogPrevoteMessageEvent(message string, prevote *message.Prevote) {

--- a/consensus/tendermint/core/prevote.go
+++ b/consensus/tendermint/core/prevote.go
@@ -56,6 +56,7 @@ func (c *Prevoter) HandlePrevote(ctx context.Context, prevote *message.Prevote) 
 		// We only process old rounds while future rounds messages are pushed on to the backlog
 		oldRoundMessages := c.messages.GetOrCreate(prevote.R())
 		prevoteContributed := oldRoundMessages.AddPrevote(prevote)
+		// note even if the vote is redundant, it might still cause a power change in case of equivocation
 		c.SendEvent(events.NewPowerChangeEvent(message.PrevoteCode, c.Height().Uint64(), c.Round(), prevote.Value()))
 
 		// Proposal would be nil if node haven't received the proposal yet.
@@ -75,6 +76,7 @@ func (c *Prevoter) HandlePrevote(ctx context.Context, prevote *message.Prevote) 
 	// will update the step to at least prevote and when it handle its on preVote(nil), then it will also have
 	// votes from other nodes.
 	prevoteContributed := c.curRoundMessages.AddPrevote(prevote)
+	// note even if the vote is redundant, it might still cause a power change in case of equivocation
 	c.SendEvent(events.NewPowerChangeEvent(message.PrevoteCode, c.Height().Uint64(), c.Round(), prevote.Value()))
 
 	c.LogPrevoteMessageEvent("MessageEvent(Prevote): Received", prevote)

--- a/consensus/tendermint/core/prevote_test.go
+++ b/consensus/tendermint/core/prevote_test.go
@@ -132,6 +132,7 @@ func TestHandlePrevote(t *testing.T) {
 			prevoteTimeout:   NewTimeout(Prevote, log.Root()),
 			backend:          backendMock,
 			step:             Prevote,
+			syncState:        &SyncState{},
 		}
 
 		c.SetDefaultHandlers()
@@ -190,6 +191,7 @@ func TestHandlePrevote(t *testing.T) {
 			round:            2,
 			height:           big.NewInt(3),
 			step:             Prevote,
+			syncState:        &SyncState{},
 		}
 		c.SetDefaultHandlers()
 		for _, prevote := range prevotes {
@@ -246,6 +248,7 @@ func TestHandlePrevote(t *testing.T) {
 			proposeTimeout:   NewTimeout(Propose, logger),
 			prevoteTimeout:   NewTimeout(Prevote, logger),
 			precommitTimeout: NewTimeout(Precommit, logger),
+			syncState:        &SyncState{},
 		}
 		c.SetDefaultHandlers()
 		for _, prevote := range prevotes {

--- a/consensus/tendermint/core/propose_test.go
+++ b/consensus/tendermint/core/propose_test.go
@@ -431,6 +431,7 @@ func TestHandleProposal(t *testing.T) {
 			precommitTimeout: NewTimeout(Precommit, logger),
 			validRound:       -1,
 			committee:        committeeSet,
+			syncState:        &SyncState{},
 		}
 
 		c.SetDefaultHandlers()
@@ -483,6 +484,7 @@ func TestHandleProposal(t *testing.T) {
 			precommitTimeout: NewTimeout(Precommit, log.Root()),
 			validRound:       0,
 			committee:        committeeSet,
+			syncState:        &SyncState{},
 		}
 
 		c.SetDefaultHandlers()

--- a/consensus/tendermint/core/timeout_test.go
+++ b/consensus/tendermint/core/timeout_test.go
@@ -89,6 +89,7 @@ func TestHandleTimeoutPrevote(t *testing.T) {
 			proposeTimeout:   NewTimeout(Propose, logger),
 			prevoteTimeout:   NewTimeout(Prevote, logger),
 			precommitTimeout: NewTimeout(Precommit, logger),
+			syncState:        &SyncState{},
 		}
 		engine.SetDefaultHandlers()
 		timeoutEvent := TimeoutEvent{

--- a/e2e_test/byzantine/raw_msg_fuzz_test.go
+++ b/e2e_test/byzantine/raw_msg_fuzz_test.go
@@ -65,8 +65,9 @@ func (fg *rawMSGFuzzer) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (fg *rawMSGFuzzer) AskSync(_ *types.Committee, _ *message.AskSyncMsg) {
+func (fg *rawMSGFuzzer) AskSync(_ *types.Committee, _ *message.AskSyncMsg) error {
 	// do nothing
+	return nil
 }
 
 func TestRawMessageFuzzer(t *testing.T) {

--- a/e2e_test/simulations/gossiper_test.go
+++ b/e2e_test/simulations/gossiper_test.go
@@ -74,9 +74,10 @@ func (cg *customGossiper) Gossip(committee *types.Committee, msg message.Msg) {
 	}
 }
 
-func (cg *customGossiper) AskSync(_ *types.Committee, _ *message.AskSyncMsg) {
+func (cg *customGossiper) AskSync(_ *types.Committee, _ *message.AskSyncMsg) error {
 	// I disable the ask sync recovery mechanism, so that I can see if the gossip only is enough to keep the network live
 	log.Info("liveness lost, supposed to ask sync (but will not)")
+	return nil
 }
 
 // this test just has the purpose of verifying that the customGossiper works as intended


### PR DESCRIPTION
Additional changes I wanted to insert in https://github.com/autonity/autonity/pull/1183 but it got merged prematurely.

Changes:
- re-introduce retries on first askSync to ensure feature parity with 2c819001db4f95d2807f987a737a1a60a08ea9f3, however by implementing the retries in the `livenessTrackerLoop` on first sync only.
- do not update the liveness timer if we receive a redundant message (i.e. a message that doesn't contribute any new voting power to Core). This is because it is not a signal of network liveness. For example we could continue receiving votes aggregated in different ways from members of  our own cluster, but the cluster itself is isolated from the rest of the network. In that case the right action to take is to askSync to everyone to try to advance the chain.
- gossip also backlogged old round messages (can happen if the local node is skipping multiple rounds)- 
- fix tests







