### PR TITLE
improve, select only F+1 AFD rule runners for large scale network.

### DIFF
--- a/consensus/tendermint/accountability/fault_detector.go
+++ b/consensus/tendermint/accountability/fault_detector.go
@@ -48,7 +48,7 @@ const (
 	offChainAccusationProofWindow = 10                           // the time window in block for one to provide off chain innocence proof before it is escalated on chain.
 	maxAccusationPerHeight        = 4                            // max number of accusation allowed to be produced by rule engine over a height against a validator.
 	maxNumOfInnocenceProofCached  = 120 * maxAccusationPerHeight // 120 blocks with 4 on each height that rule engine can produce totally over a height.
-	reportingSlotPeriod           = 20                           // Each AFD reporting slot holds 20 blocks, each validator response for a slot.
+	reportingSlotPeriod           = uint64(20)                   // Each AFD reporting slot holds 20 blocks, each validator response for a slot.
 )
 
 var (

--- a/consensus/tendermint/accountability/fault_detector.go
+++ b/consensus/tendermint/accountability/fault_detector.go
@@ -359,6 +359,11 @@ loop:
 				if alreadyScanned {
 					continue
 				}
+
+				if !fd.isRuleEngineRunner(h) {
+					continue
+				}
+
 				if events := fd.runRuleEngine(h); len(events) > 0 {
 					fd.pendingEvents = append(fd.pendingEvents, events...)
 				}
@@ -427,26 +432,6 @@ loop:
 			break loop
 		}
 	}
-}
-
-// canReport assign the validator a dedicated time-window to submit the accountability event
-// TODO: consider including smart contract side enforcement
-func (fd *FaultDetector) canReport(height uint64) bool {
-	committee, err := fd.blockchain.CommitteeByHeight(height)
-	if err != nil {
-		fd.logger.Crit("Can't retrieve committee for message", "err", err, "height", height)
-	}
-
-	// each validator is assigned a reporting slot
-	reporterIndex := (height / reportingSlotPeriod) % uint64(committee.Len())
-
-	// TODO: consider allowing the validator to report for the entirety of the period
-	// if validator is the reporter of the slot period, and if checkpoint block is the end block of the
-	// slot, then it is time to report the collected events by this validator.
-	if height%reportingSlotPeriod != 0 {
-		return false
-	}
-	return committee.Members[reporterIndex].Address == fd.address
 }
 
 func (fd *FaultDetector) Stop() {

--- a/consensus/tendermint/accountability/reporter.go
+++ b/consensus/tendermint/accountability/reporter.go
@@ -2,11 +2,12 @@ package accountability
 
 import (
 	"errors"
-
 	"github.com/autonity/autonity/autonity"
 	"github.com/autonity/autonity/autonity/bindings"
 	"github.com/autonity/autonity/common"
+	"github.com/autonity/autonity/consensus/tendermint/bft"
 	"github.com/autonity/autonity/core/types"
+	"math/big"
 )
 
 const (
@@ -19,9 +20,9 @@ var (
 	errPendingReport = errors.New("pending report")
 )
 
-// primaryIndex returns the index of the validator which is assigned with a reporting block period.
-func primaryIndex(height uint64, committeeSize uint64) int {
-	return int((height / reportingSlotPeriod) % committeeSize) //nolint
+// primaryIndex returns the index of the validator which is the primary reporter of a specific 20-blocks reporting window.
+func primaryIndex(height uint64, committeeSize uint64) uint64 {
+	return (height / reportingSlotPeriod) % committeeSize
 }
 
 // isRuleEngineRunner check if client is a rule engine runner, as to reduce the performance cost in a large scale
@@ -35,43 +36,43 @@ func (fd *FaultDetector) isRuleEngineRunner(height uint64) bool {
 		return false
 	}
 
+	committeeSize := uint64(committee.Len())
 	// All members run rule engine in a small scale network.
-	if committee.Len() <= SmallScaleNetSize {
+	if committeeSize <= SmallScaleNetSize {
 		return true
 	}
 
-	validator := committee.MemberByAddress(fd.address)
-	if validator == nil {
+	currClient := committee.MemberByAddress(fd.address)
+	if currClient == nil {
 		return false
 	}
 
 	// With a larger network, we select primary and backups reporters.
 	// Return true if node is the primary reporter.
-	primary := primaryIndex(height, uint64(committee.Len())) //nolint
-	if committee.Members[primary].Address == fd.address {
+	pri := primaryIndex(height, committeeSize)
+	if committee.Members[pri].Address == fd.address {
 		return true
 	}
 
-	// Beside the primary, we select other 1/3 nodes as backups, thus there
-	// will be at least 1 honest node runs rule engine.
-	numBackups := committee.Len() / 3
-	startIdx := primary + 1
-	endIdx := primary + numBackups
-	validatorIdx := int(validator.Index) //nolint
+	// If the client is not the primary reporter, check if they are backup reporters.
+	total := new(big.Int).SetUint64(committeeSize)
+	f := bft.F(total).Uint64()
+	startIdx := pri + 1
+	endIdx := pri + f
+	valIdx := currClient.Index
 
-	if endIdx < committee.Len() {
-		return validatorIdx >= startIdx && validatorIdx <= endIdx
+	if endIdx < committeeSize {
+		return valIdx >= startIdx && valIdx <= endIdx
 	}
 
-	if startIdx == committee.Len() {
-		endIdx = endIdx % committee.Len()
-		return validatorIdx >= 0 && validatorIdx <= endIdx
+	if startIdx == committeeSize {
+		endIdx = endIdx % committeeSize
+		return valIdx >= 0 && valIdx <= endIdx
 	}
 
-	wrappedEndIdx := endIdx % committee.Len()
-	startIdx = (primary + 1) % committee.Len()
-	return (validatorIdx >= startIdx && validatorIdx < committee.Len()) ||
-		(validatorIdx >= 0 && validatorIdx <= wrappedEndIdx)
+	wrappedEndIdx := endIdx % committeeSize
+	startIdx = (pri + 1) % committeeSize
+	return (valIdx >= startIdx && valIdx < committeeSize) || (valIdx >= 0 && valIdx <= wrappedEndIdx)
 }
 
 // canReport assign the validator a dedicated time-window to submit the accountability event, if the primary fails to
@@ -83,7 +84,7 @@ func (fd *FaultDetector) canReport(height uint64) bool {
 	}
 
 	// each validator is assigned a reporting slot
-	primary := primaryIndex(height, uint64(committee.Len())) //nolint
+	primary := primaryIndex(height, uint64(committee.Len()))
 
 	// if validator is the reporter of the slot period, and if checkpoint block is the end block of the
 	// slot, then it is time to report the collected events by this validator.

--- a/consensus/tendermint/accountability/reporter.go
+++ b/consensus/tendermint/accountability/reporter.go
@@ -10,13 +10,88 @@ import (
 )
 
 const (
-	MaxEventSize = 20480 // 20KB
+	MaxEventSize      = 20480 // 20KB
+	SmallScaleNetSize = 32
 )
 
 var (
 	errInvalidReport = errors.New("invalid report")
 	errPendingReport = errors.New("pending report")
 )
+
+// primaryIndex returns the index of the validator which is assigned with a reporting block period.
+func primaryIndex(height uint64, committeeSize uint64) int {
+	return int((height / reportingSlotPeriod) % committeeSize) //nolint
+}
+
+// isRuleEngineRunner check if client is a rule engine runner, as to reduce the performance cost in a large scale
+// network which contains a lots of consensus message to be scanned, we select a set of nodes as the rule runner
+// of a specific height, for smale scale network, all the nodes run the rule engine.
+func (fd *FaultDetector) isRuleEngineRunner(height uint64) bool {
+
+	committee, err := fd.blockchain.CommitteeByHeight(height)
+	if err != nil {
+		fd.logger.Error("Failed to get committee for height %d: %v", height, err)
+		return false
+	}
+
+	// All members run rule engine in a small scale network.
+	if committee.Len() <= SmallScaleNetSize {
+		return true
+	}
+
+	validator := committee.MemberByAddress(fd.address)
+	if validator == nil {
+		return false
+	}
+
+	// With a larger network, we select primary and backups reporters.
+	// Return true if node is the primary reporter.
+	primary := primaryIndex(height, uint64(committee.Len())) //nolint
+	if committee.Members[primary].Address == fd.address {
+		return true
+	}
+
+	// Beside the primary, we select other 1/3 nodes as backups, thus there
+	// will be at least 1 honest node runs rule engine.
+	numBackups := committee.Len() / 3
+	startIdx := primary + 1
+	endIdx := primary + numBackups
+	validatorIdx := int(validator.Index) //nolint
+
+	if endIdx < committee.Len() {
+		return validatorIdx >= startIdx && validatorIdx <= endIdx
+	}
+
+	if startIdx == committee.Len() {
+		endIdx = endIdx % committee.Len()
+		return validatorIdx >= 0 && validatorIdx <= endIdx
+	}
+
+	wrappedEndIdx := endIdx % committee.Len()
+	startIdx = (primary + 1) % committee.Len()
+	return (validatorIdx >= startIdx && validatorIdx < committee.Len()) ||
+		(validatorIdx >= 0 && validatorIdx <= wrappedEndIdx)
+}
+
+// canReport assign the validator a dedicated time-window to submit the accountability event, if the primary fails to
+// report, those backups will report once they become to primary at next dedicated time-window.
+func (fd *FaultDetector) canReport(height uint64) bool {
+	committee, err := fd.blockchain.CommitteeByHeight(height)
+	if err != nil {
+		fd.logger.Crit("Can't retrieve committee for message", "err", err, "height", height)
+	}
+
+	// each validator is assigned a reporting slot
+	primary := primaryIndex(height, uint64(committee.Len())) //nolint
+
+	// if validator is the reporter of the slot period, and if checkpoint block is the end block of the
+	// slot, then it is time to report the collected events by this validator.
+	if height%reportingSlotPeriod != 0 {
+		return false
+	}
+	return committee.Members[primary].Address == fd.address
+}
 
 func (fd *FaultDetector) reportEvents(events []*bindings.IAccountabilityEvent) []*bindings.IAccountabilityEvent {
 	var filtered []*bindings.IAccountabilityEvent


### PR DESCRIPTION
This PR inroduces an improvement in AFD, as in a large scale network, there will be a lots of consensus messages to be scanned by AFD rule engine, running rule engine on every single node waste a lot of computing power as only the primary reporter node have to report an AFD event with the dedicated reporting window. Thus, we just select a sub set (F+1) of backup nodes of the primary reporter node, running rule engine with these selected nodes, saves the computing power of the network. On the selection of backups, we pick up those nodes who will become primary reporter at the upcoming dedicated reporting time windows, thus there won't be any missing of accounting.