### PR TITLE
fix an edge case in AggregateDistinctPrecommits as the assumption is no longer valid.

### DIFF
--- a/consensus/tendermint/accountability/distinct_msg_aggregator.go
+++ b/consensus/tendermint/accountability/distinct_msg_aggregator.go
@@ -278,12 +278,11 @@ func AggregateDistinctPrecommits(precommits []*message.Precommit) HighlyAggregat
 	var precommitsToBeAggregated []*message.Precommit
 
 	presentedMsgs := make(map[int64]map[common.Hash]struct{})
-
-	precommitsToBeAggregated = append(precommitsToBeAggregated, precommits[0])
 	height := precommits[0].H()
 
-	// skip duplicated msg
-	for i := 1; i < len(precommits); i++ {
+	// skip duplicated precommits as aggregation can produce multiple instance of precommit
+	// with the same signer and value, to a single signer, one instance of precommit is sufficient to prove its behaviour.
+	for i := 0; i < len(precommits); i++ {
 		roundMap, ok := presentedMsgs[precommits[i].R()]
 		if !ok {
 			roundMap = make(map[common.Hash]struct{})

--- a/consensus/tendermint/accountability/distinct_msg_aggregator.go
+++ b/consensus/tendermint/accountability/distinct_msg_aggregator.go
@@ -282,16 +282,16 @@ func AggregateDistinctPrecommits(precommits []*message.Precommit) HighlyAggregat
 
 	// skip duplicated precommits as aggregation can produce multiple instance of precommit
 	// with the same signer and value, to a single signer, one instance of precommit is sufficient to prove its behaviour.
-	for i := 0; i < len(precommits); i++ {
-		roundMap, ok := presentedMsgs[precommits[i].R()]
+	for _, m := range precommits {
+		roundMap, ok := presentedMsgs[m.R()]
 		if !ok {
 			roundMap = make(map[common.Hash]struct{})
-			presentedMsgs[precommits[i].R()] = roundMap
+			presentedMsgs[m.R()] = roundMap
 		}
 
-		if _, ok := roundMap[precommits[i].Value()]; !ok {
-			roundMap[precommits[i].Value()] = struct{}{}
-			precommitsToBeAggregated = append(precommitsToBeAggregated, precommits[i])
+		if _, ok := roundMap[m.Value()]; !ok {
+			roundMap[m.Value()] = struct{}{}
+			precommitsToBeAggregated = append(precommitsToBeAggregated, m)
 		}
 	}
 


### PR DESCRIPTION
This PR fixs an edge case in the distinct message aggregator which was used by AFD, as the legacy assumption is not valid anymore.