### PR TITLE
[BUGFIX] fix clustering setup at epoch switch

### DIFF
--- a/consensus/tendermint/router/routing.go
+++ b/consensus/tendermint/router/routing.go
@@ -147,7 +147,7 @@ func (m *Router) Recipients(committee *types.Committee, msg message.Msg, from co
 	}
 	recipients, err := m.peerSelector.SelectPeers(committee, msg, from)
 	if err != nil {
-		m.logger.Debug("selector: no clusters, falling back to all committee members")
+		m.logger.Error("selector: no clusters, falling back to all committee members", "err", err)
 		return m.committeeAddresses(committee), nil
 	}
 	return recipients, nil
@@ -231,13 +231,15 @@ func (m *Router) Start(ctx context.Context, chain interfaces.BlockChainProvider)
 	}
 	m.committee = addresses
 	m.inCommittee = curEpoch.Committee.MemberByAddress(m.self) != nil
-	nw, err := cluster.New(addresses, m.latestLatencies, m.self)
 	m.chain = chain
 	m.clusteringThreshold = m.clusteringThresholdByHeight(curEpoch.EpochBlock.Uint64() + 1)
-	if err != nil {
-		m.logger.Error("Router: failed to create network", "err", err)
-	} else {
-		m.updateNetwork(nw)
+	if m.inCommittee && int64(len(m.committee)) >= m.clusteringThreshold {
+		nw, err := cluster.New(addresses, m.latestLatencies, m.self)
+		if err != nil {
+			m.logger.Error("Router: failed to create network", "err", err)
+		} else {
+			m.updateNetwork(nw)
+		}
 	}
 	ctx, m.cancel = context.WithCancel(ctx)
 	m.wg.Add(1)
@@ -391,8 +393,10 @@ func (m *Router) loop(ctx context.Context) {
 			m.logger.Info("Router: new epoch detected", "height", epochEv.Header.Number.String())
 			epoch := epochEv.Header.Epoch
 			m.inCommittee = epoch.Committee.MemberByAddress(m.self) != nil
+			m.updateCommittee(epoch)
+			m.clusteringThreshold = m.clusteringThresholdByHeight(epochEv.Header.Number.Uint64() + 1)
 			if !m.inCommittee || int64(len(m.committee)) < m.clusteringThreshold {
-				m.logger.Info("Router: clustering not needed, skipping measurement")
+				m.logger.Info("Router: clustering not needed, skipping measurement", "committee len", len(m.committee), "clusteringThreshold", m.clusteringThreshold)
 				if wasClustering {
 					// reset cluster
 					m.updateNetwork(cluster.Clusters{})
@@ -401,8 +405,6 @@ func (m *Router) loop(ctx context.Context) {
 				continue
 			}
 			wasClustering = true
-			m.updateCommittee(epoch)
-			m.clusteringThreshold = m.clusteringThresholdByHeight(epochEv.Header.Number.Uint64() + 1)
 			// we should never fail here, as we already made sure that we are in committee
 			nw, err := cluster.New(m.committee, m.Latencies(), m.self)
 			if err != nil {


### PR DESCRIPTION
Fixes:
- Do not update clusters at node start if below clustering threshold
- At epoch switch, update committee and clustering threshold before using them