### PR TITLE
Decoding optimizations

### DIFF
--- a/consensus/tendermint/accountability/contracts_test.go
+++ b/consensus/tendermint/accountability/contracts_test.go
@@ -152,7 +152,9 @@ func TestDecodeAndVerifyProofs(t *testing.T) {
 				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.Proof.Rule, decodeProof.Rule)
-			assert.Equal(t, tc.Proof.Message.Signature(), decodeProof.Message.Signature())
+			msgSignature, _ := tc.Proof.Message.Signature()
+			decodeProofSignature, _ := decodeProof.Message.Signature()
+			assert.Equal(t, msgSignature, decodeProofSignature)
 			assert.Equal(t, tc.Proof.Evidences, decodeProof.Evidences)
 			assert.Equal(t, tc.Proof.DistinctPrecommits.Len(), decodeProof.DistinctPrecommits.Len())
 			assert.Equal(t, true, decodeProof.DistinctPrecommits.validated)
@@ -471,8 +473,9 @@ func TestMisbehaviourVerifier(t *testing.T) {
 			SignersIndex: pcForVPVO12.Signers().FlattenUniq(),
 			SignersCoeff: pcForVPVO12.Signers().CopyCoefficients(),
 		}},
-		Signature: pcForVPVO12.Signature().Marshal(),
 	}
+	s, _ := pcForVPVO12.Signature()
+	missingPrecommitPVO12.Signature = s.Marshal()
 	err := missingPrecommitPVO12.PreValidate(parent.Epoch.Committee, height)
 	require.NoError(t, err)
 	err = missingPrecommitPVO12.Validate()

--- a/consensus/tendermint/accountability/distinct_msg_aggregator.go
+++ b/consensus/tendermint/accountability/distinct_msg_aggregator.go
@@ -328,7 +328,7 @@ func AggregateDistinctPrecommits(precommits []*message.Precommit) HighlyAggregat
 			SignersCoeff: m.Signers().CopyCoefficients(),
 		}
 		result.MsgSigners = append(result.MsgSigners, roundValueSigners)
-		signatures[i] = m.Signature()
+		signatures[i], _ = m.Signature()
 	}
 	result.Height = height
 	result.Signature = blst.AggregateSignatures(signatures).Marshal()

--- a/consensus/tendermint/accountability/distinct_msg_aggregator_test.go
+++ b/consensus/tendermint/accountability/distinct_msg_aggregator_test.go
@@ -249,7 +249,7 @@ func maliciousAggregatePrecommits(precommits []*message.Precommit, wrongHeight *
 			SignersCoeff: coeffs,
 		}
 		result.MsgSigners = append(result.MsgSigners, roundValueSigners)
-		signatures[i] = m.Signature()
+		signatures[i], _ = m.Signature()
 	}
 	result.Height = defaultHeight
 	result.Signature = blst.AggregateSignatures(signatures).Marshal()

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -425,6 +425,7 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 	}
 
 	// at least one of the signatures is invalid, find at which index
+	reInjectFiltered = true
 	invalids := blst.FindInvalid(signatures, publicKeys, hash)
 	if metrics.Enabled {
 		InvalidBg.Add(int64(len(invalids)))
@@ -440,7 +441,6 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 			continue
 		}
 		a.logger.Info("Received invalid bls signature from", "peer", event.Sender)
-		reInjectFiltered = true
 		a.handleInvalidMessage(event, message.ErrBadSignature)
 	}
 	a.aggregateAndDispatch(validVotes, eventer)

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -83,6 +83,7 @@ func newAggregator(backend interfaces.Backend, core interfaces.Core, logger log.
 		internalCoreCh:    make(chan events.MessageEventer, 1),
 		internalFdCh:      make(chan events.MessageEventer, 1),
 		internalBacklogCh: make(chan events.UnverifiedMessageEvent, 1000),
+		computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 1000),
 		signerSetCache:    newAggregatorCache(),
 	}
 }

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -385,7 +385,14 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 	candidates := make([]events.UnverifiedMessageEvent, 0, len(batch))
 	publicKeys := make([]blst.PublicKey, 0, len(batch))
 	signatures := make([]blst.Signature, 0, len(batch))
+	reInjectFiltered := false
 
+	defer func() {
+		if reInjectFiltered {
+			// we have a backup of filtered messages, re-inject them in the backlog channel
+			a.reInjectFilteredMessages(batch[0].Message.(message.Vote))
+		}
+	}()
 	for _, event := range batch {
 		m := event.Message.(message.Vote)
 		publicKey := m.SignerKey()
@@ -394,6 +401,7 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 			a.logger.Debug("Signature decoding failed for message", "peer", event.Sender, "err", err)
 			a.handleInvalidMessage(event.ErrCh, err, event.Sender)
 			a.signerSetCache.invalidateVotes(m)
+			reInjectFiltered = true
 			continue
 		}
 		candidates = append(candidates, event)
@@ -426,6 +434,7 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 	invalidSet := make(map[int]struct{}, len(invalids))
 	for _, idx := range invalids {
 		invalidSet[int(idx)] = struct{}{} // #nosec
+		reInjectFiltered = true
 	}
 	validVotes := make([]message.Vote, 0, len(candidates)-len(invalids))
 	for i, event := range candidates {
@@ -436,9 +445,6 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 		a.logger.Info("Received invalid bls signature from", "peer", event.Sender)
 		a.handleInvalidMessage(event.ErrCh, message.ErrBadSignature, event.Sender)
 		a.signerSetCache.invalidateVotes(event.Message.(message.Vote))
-	}
-	if len(invalids) > 0 {
-		a.reInjectFilteredMessages(batch[0].Message.(message.Vote))
 	}
 	a.aggregateAndDispatch(validVotes, eventer)
 }
@@ -490,7 +496,11 @@ func (a *aggregator) processProposal(proposalEvent events.UnverifiedMessageEvent
 	a.internalFdCh <- eventer(proposal, proposalEvent.ErrCh, proposalEvent.Sender, proposalEvent.Disseminated).(events.MessageEventer)   // send to fault detector
 }
 
-func (a *aggregator) isSignerJailed(vote message.Vote, committee *types.Committee) bool {
+func (a *aggregator) isSignerJailed(msg message.Msg, committee *types.Committee) bool {
+	vote, ok := msg.(message.Vote)
+	if !ok {
+		return false
+	}
 	// check if all signers of the message are jailed
 	if a.backend.JailedCount() >= vote.Signers().Len() {
 		allJailed := true
@@ -518,10 +528,6 @@ func (a *aggregator) handleVote(voteEvent events.UnverifiedMessageEvent, committ
 	round := vote.R()
 	code := vote.Code()
 	value := vote.Value()
-
-	if a.isSignerJailed(vote, committee) {
-		return
-	}
 
 	a.saveMessage(voteEvent)
 
@@ -588,6 +594,9 @@ func (a *aggregator) handleEvent(event events.UnverifiedMessageEvent) {
 	}
 	if a.signerSetCache.filter(event) {
 		return // already processed a message with more signers
+	}
+	if a.isSignerJailed(msg, committee) {
+		return
 	}
 	// mark committee size for the height to avoid any more calls to CommitteeByHeight
 	a.signerSetCache.markCommittee(msg.H(), committee)

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -83,7 +83,7 @@ func newAggregator(backend interfaces.Backend, core interfaces.Core, logger log.
 		internalCoreCh:    make(chan events.MessageEventer, 1),
 		internalFdCh:      make(chan events.MessageEventer, 1),
 		internalBacklogCh: make(chan events.UnverifiedMessageEvent, 1000),
-		computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 1000),
+		computeWorkersCh:  make(chan events.UnverifiedMessageEvent, aggregatorMessageQueue),
 		signerSetCache:    newAggregatorCache(),
 	}
 }

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -139,7 +139,7 @@ func (a *aggregator) start(ctx context.Context) {
 		a.internalBacklogCh = make(chan events.UnverifiedMessageEvent, 1000) // buffered to avoid deadlock
 	}
 	if a.computeWorkersCh == nil {
-		a.computeWorkersCh = make(chan events.UnverifiedMessageEvent, 1000)
+		a.computeWorkersCh = make(chan events.UnverifiedMessageEvent, aggregatorMessageQueue)
 	}
 	a.wg.Add(numComputeWorkers)
 	for i := 0; i < numComputeWorkers; i++ {
@@ -357,7 +357,7 @@ func (a *aggregator) filterSkipped(evs []events.UnverifiedMessageEvent) []events
 	filtered := make([]events.UnverifiedMessageEvent, 0, len(evs))
 	for _, e := range evs {
 		m := e.Message
-		// skip messages to be ignored or that are already in core
+		// skip messages to be ignored
 		if a.toSkip(m) {
 			continue
 		}

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -117,7 +117,7 @@ type aggregator struct {
 	internalFdCh      chan events.MessageEventer
 	internalBacklogCh chan events.UnverifiedMessageEvent // backlog for messages that were filtered by cache, but reinjected
 
-	computeWorkers chan events.UnverifiedMessageEvent
+	computeWorkersCh chan events.UnverifiedMessageEvent
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -137,8 +137,8 @@ func (a *aggregator) start(ctx context.Context) {
 	if a.internalBacklogCh == nil {
 		a.internalBacklogCh = make(chan events.UnverifiedMessageEvent, 1000) // buffered to avoid deadlock
 	}
-	if a.computeWorkers == nil {
-		a.computeWorkers = make(chan events.UnverifiedMessageEvent, 1000)
+	if a.computeWorkersCh == nil {
+		a.computeWorkersCh = make(chan events.UnverifiedMessageEvent, 1000)
 	}
 	a.wg.Add(numComputeWorkers)
 	for i := 0; i < numComputeWorkers; i++ {
@@ -154,7 +154,7 @@ func (a *aggregator) start(ctx context.Context) {
 func (a *aggregator) computeWork(ctx context.Context) {
 	for {
 		select {
-		case ev := <-a.computeWorkers:
+		case ev := <-a.computeWorkersCh:
 			// trigger the lazy computations
 			ev.Message.SignerKey()
 			_, _ = ev.Message.Signature() // error will be captured later during validation
@@ -164,9 +164,10 @@ func (a *aggregator) computeWork(ctx context.Context) {
 	}
 }
 
-func (a *aggregator) handleInvalidMessage(errorCh chan<- error, err error, sender common.Address) {
-	tryDisconnect(errorCh, err)
-	for _, hash := range a.messagesFrom[sender] {
+func (a *aggregator) handleInvalidMessage(event events.UnverifiedMessageEvent, err error) {
+	tryDisconnect(event.ErrCh, err)
+	a.signerSetCache.invalidateVotes(event.Message.(message.Vote))
+	for _, hash := range a.messagesFrom[event.Sender] {
 		a.toIgnore[hash] = struct{}{}
 	}
 }
@@ -399,8 +400,7 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 		signature, err := m.Signature()
 		if err != nil {
 			a.logger.Debug("Signature decoding failed for message", "peer", event.Sender, "err", err)
-			a.handleInvalidMessage(event.ErrCh, err, event.Sender)
-			a.signerSetCache.invalidateVotes(m)
+			a.handleInvalidMessage(event, err)
 			reInjectFiltered = true
 			continue
 		}
@@ -426,15 +426,12 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 
 	// at least one of the signatures is invalid, find at which index
 	invalids := blst.FindInvalid(signatures, publicKeys, hash)
-	defer func() {
-		if metrics.Enabled {
-			InvalidBg.Add(int64(len(invalids)))
-		}
-	}()
+	if metrics.Enabled {
+		InvalidBg.Add(int64(len(invalids)))
+	}
 	invalidSet := make(map[int]struct{}, len(invalids))
 	for _, idx := range invalids {
 		invalidSet[int(idx)] = struct{}{} // #nosec
-		reInjectFiltered = true
 	}
 	validVotes := make([]message.Vote, 0, len(candidates)-len(invalids))
 	for i, event := range candidates {
@@ -443,8 +440,8 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 			continue
 		}
 		a.logger.Info("Received invalid bls signature from", "peer", event.Sender)
-		a.handleInvalidMessage(event.ErrCh, message.ErrBadSignature, event.Sender)
-		a.signerSetCache.invalidateVotes(event.Message.(message.Vote))
+		reInjectFiltered = true
+		a.handleInvalidMessage(event, message.ErrBadSignature)
 	}
 	a.aggregateAndDispatch(validVotes, eventer)
 }
@@ -496,9 +493,9 @@ func (a *aggregator) processProposal(proposalEvent events.UnverifiedMessageEvent
 	a.internalFdCh <- eventer(proposal, proposalEvent.ErrCh, proposalEvent.Sender, proposalEvent.Disseminated).(events.MessageEventer)   // send to fault detector
 }
 
-func (a *aggregator) isSignerJailed(msg message.Msg, committee *types.Committee) bool {
+func (a *aggregator) areAllSignersJailed(msg message.Msg, committee *types.Committee) bool {
 	vote, ok := msg.(message.Vote)
-	if !ok {
+	if !ok { // proposals are already checked for jailing in backend handler
 		return false
 	}
 	// check if all signers of the message are jailed
@@ -558,7 +555,7 @@ func (a *aggregator) handleVote(voteEvent events.UnverifiedMessageEvent, committ
 		}
 	}
 	// blocking call to trigger lazy computations of signatures and pubkeys
-	a.computeWorkers <- voteEvent
+	a.computeWorkersCh <- voteEvent
 }
 
 func (a *aggregator) toSkip(msg message.Msg) bool {
@@ -595,7 +592,7 @@ func (a *aggregator) handleEvent(event events.UnverifiedMessageEvent) {
 	if a.signerSetCache.filter(event) {
 		return // already processed a message with more signers
 	}
-	if a.isSignerJailed(msg, committee) {
+	if a.areAllSignersJailed(msg, committee) {
 		return
 	}
 	// mark committee size for the height to avoid any more calls to CommitteeByHeight
@@ -777,6 +774,7 @@ func (a *aggregator) stop() {
 	a.logger.Info("Stopping the aggregator routine")
 	a.cancel()
 	a.wg.Wait()
+	a.computeWorkersCh = nil
 	a.internalCoreCh = nil
 	a.internalFdCh = nil
 	a.internalBacklogCh = nil

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -379,6 +379,9 @@ func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEve
 	if len(batch) == 0 {
 		return
 	}
+	if metrics.Enabled {
+		BatchesBg.Add(int64(len(batch)))
+	}
 	candidates := make([]events.UnverifiedMessageEvent, 0, len(batch))
 	publicKeys := make([]blst.PublicKey, 0, len(batch))
 	signatures := make([]blst.Signature, 0, len(batch))
@@ -487,12 +490,38 @@ func (a *aggregator) processProposal(proposalEvent events.UnverifiedMessageEvent
 	a.internalFdCh <- eventer(proposal, proposalEvent.ErrCh, proposalEvent.Sender, proposalEvent.Disseminated).(events.MessageEventer)   // send to fault detector
 }
 
+func (a *aggregator) isSignerJailed(vote message.Vote, committee *types.Committee) bool {
+	// check if all signers of the message are jailed
+	if a.backend.JailedCount() >= vote.Signers().Len() {
+		allJailed := true
+		vote.Signers().ForEachDistinctSigner(func(signerIndex int) {
+			signer := committee.Members[signerIndex].Address
+			if !a.backend.IsJailed(signer) {
+				allJailed = false
+			}
+		})
+		// unless all signers are jailed, we still process aggregates
+		if allJailed {
+			a.logger.Debug("Vote message contains only signatures from jailed validators, ignoring message", "signers", vote.Signers().String())
+			return true
+		}
+	}
+	return false
+}
+
+// assumes current or old round vote
+// if add == true, the msg is saved in the aggregator.
+// if add == false, the msg is not saved and only the power checks are done.
 func (a *aggregator) handleVote(voteEvent events.UnverifiedMessageEvent, committee *types.Committee) {
 	vote := voteEvent.Message.(message.Vote)
 	height := vote.H()
 	round := vote.R()
 	code := vote.Code()
 	value := vote.Value()
+
+	if a.isSignerJailed(vote, committee) {
+		return
+	}
 
 	a.saveMessage(voteEvent)
 

--- a/consensus/tendermint/backend/aggregator.go
+++ b/consensus/tendermint/backend/aggregator.go
@@ -23,6 +23,7 @@ const (
 	aggregationPeriod            = 150 * time.Millisecond
 	oldMessagesAggregationPeriod = 2 * time.Second
 	oldMessagesStatsPeriod       = 2 * time.Second
+	numComputeWorkers            = 8
 )
 
 // aggregator metrics
@@ -116,6 +117,8 @@ type aggregator struct {
 	internalFdCh      chan events.MessageEventer
 	internalBacklogCh chan events.UnverifiedMessageEvent // backlog for messages that were filtered by cache, but reinjected
 
+	computeWorkers chan events.UnverifiedMessageEvent
+
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 	logger log.Logger
@@ -134,8 +137,31 @@ func (a *aggregator) start(ctx context.Context) {
 	if a.internalBacklogCh == nil {
 		a.internalBacklogCh = make(chan events.UnverifiedMessageEvent, 1000) // buffered to avoid deadlock
 	}
+	if a.computeWorkers == nil {
+		a.computeWorkers = make(chan events.UnverifiedMessageEvent, 1000)
+	}
+	a.wg.Add(numComputeWorkers)
+	for i := 0; i < numComputeWorkers; i++ {
+		go func() {
+			defer a.wg.Done()
+			a.computeWork(ctx)
+		}()
+	}
 	a.wg.Add(1)
 	go a.loop(ctx)
+}
+
+func (a *aggregator) computeWork(ctx context.Context) {
+	for {
+		select {
+		case ev := <-a.computeWorkers:
+			// trigger the lazy computations
+			ev.Message.SignerKey()
+			_, _ = ev.Message.Signature() // error will be captured later during validation
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func (a *aggregator) handleInvalidMessage(errorCh chan<- error, err error, sender common.Address) {
@@ -325,90 +351,6 @@ func (a *aggregator) DispatchFaultDetectorEvents(_ context.Context) {
 	}()
 }
 
-// validates a batch of messages, returns valid votes
-func (a *aggregator) validateBatch(batch []events.UnverifiedMessageEvent) (valid []message.Vote, invalid []uint) {
-	publicKeys := make([]blst.PublicKey, len(batch))
-	signatures := make([]blst.Signature, len(batch))
-	messages := make([]message.Vote, len(batch))
-	senders := make([]common.Address, len(batch))
-	errChs := make([]chan<- error, len(batch))
-
-	for i, e := range batch {
-		m := e.Message
-		messages[i] = m.(message.Vote)
-		//note: could do the signerKey calculation before hand - in parallel
-		publicKeys[i] = m.SignerKey()
-		signatures[i] = m.Signature()
-		senders[i] = e.Sender
-		errChs[i] = e.ErrCh
-	}
-
-	// if all messages in the batch got skipped, move to the next batch
-	if len(signatures) == 0 {
-		return nil, nil
-	}
-
-	hash := batch[0].Message.SignatureInput()
-
-	if blst.FastAggregateVerifyBatch(signatures, publicKeys, hash) {
-		// all signatures are valid
-		return messages, nil
-	}
-
-	validVotes := make([]message.Vote, 0, len(batch))
-
-	// at least one of the signatures is invalid, find at which index
-	invalids := blst.FindInvalid(signatures, publicKeys, hash)
-
-	// remove invalid messages and sent the rest of the batch
-	// NOTE: the following loop relies on blst.FindInvalid returning invalid indexes sorted according to ascending order
-	j := 0
-	for i, msg := range messages {
-		// #nosec
-		if j < len(invalids) && uint(i) == invalids[j] {
-			j++
-			a.signerSetCache.invalidateVotes(msg)
-			continue
-		}
-		validVotes = append(validVotes, msg)
-	}
-
-	var filtered []events.UnverifiedMessageEvent
-	switch batch[0].Message.(type) {
-	case *message.Prevote, *message.Precommit:
-		filtered = a.signerSetCache.emptyFiltered(
-			batch[0].Message.H(),
-			batch[0].Message.R(),
-			batch[0].Message.Code(),
-			batch[0].Message.Value(),
-		)
-	default:
-		// len(filtered) = 0
-	}
-	warned := false
-	for i, e := range filtered {
-		select {
-		case a.internalBacklogCh <- e:
-		// reinject the filtered messages to the backlog
-		default:
-			if !warned {
-				log.Warn(
-					"Aggregator backlog channel is full, dropping messages",
-					"number of messages dropped",
-					len(filtered)-i,
-					"height", batch[0].Message.H(),
-					"round", batch[0].Message.R(),
-					"code", batch[0].Message.Code(),
-					"value", batch[0].Message.Value(),
-				)
-				warned = true
-			}
-		}
-	}
-
-	return validVotes, invalids
-}
-
 func (a *aggregator) filterSkipped(evs []events.UnverifiedMessageEvent) []events.UnverifiedMessageEvent {
 	filtered := make([]events.UnverifiedMessageEvent, 0, len(evs))
 	for _, e := range evs {
@@ -427,54 +369,115 @@ func (a *aggregator) processBatches(batches [][]events.UnverifiedMessageEvent, e
 	if len(batches) == 0 {
 		return
 	}
-
-	processed := 0 // messages that go in the aggregator
-	sent := 0      // messages that out of the aggregator (to Core and FD as valid msgs)
 	for _, batch := range batches {
-		if len(batch) == 0 {
+		batch = a.filterSkipped(batch) // filter out messages that are to be skipped
+		a.processAndValidateBatch(batch, eventer)
+	}
+}
+
+func (a *aggregator) processAndValidateBatch(batch []events.UnverifiedMessageEvent, eventer eventBuilder) {
+	if len(batch) == 0 {
+		return
+	}
+	candidates := make([]events.UnverifiedMessageEvent, 0, len(batch))
+	publicKeys := make([]blst.PublicKey, 0, len(batch))
+	signatures := make([]blst.Signature, 0, len(batch))
+
+	for _, event := range batch {
+		m := event.Message.(message.Vote)
+		publicKey := m.SignerKey()
+		signature, err := m.Signature()
+		if err != nil {
+			a.logger.Debug("Signature decoding failed for message", "peer", event.Sender, "err", err)
+			a.handleInvalidMessage(event.ErrCh, err, event.Sender)
+			a.signerSetCache.invalidateVotes(m)
 			continue
 		}
-		if metrics.Enabled {
-			BatchesBg.Add(int64(len(batch)))
-		}
-		processed += len(batch)
-		// we need to filter first so that invalids indexes will actually be correct
-		batch = a.filterSkipped(batch) // filter out messages that are to be skipped
-		validVotes, invalids := a.validateBatch(batch)
-		sent += len(validVotes)
-		if len(validVotes) > 0 {
-			// dispatch messages to core and FD
-			// repetitive code but I didn't find a way to declare aggregateVotes so that it works both with prevote and precommit
-			switch validVotes[0].(type) {
-			case *message.Prevote:
-				aggregateVotes := message.AggregatePrevotes(validVotes)
-				for _, aggregateVote := range aggregateVotes {
-					a.signerSetCache.addVote(aggregateVote, stepDispatched)
-					a.internalCoreCh <- eventer(aggregateVote, nil, a.backend.Address(), false).(events.MessageEventer)
-					a.internalFdCh <- eventer(aggregateVote, nil, a.backend.Address(), false).(events.MessageEventer)
-				}
-			case *message.Precommit:
-				aggregateVotes := message.AggregatePrecommits(validVotes)
-				for _, aggregateVote := range aggregateVotes {
-					a.signerSetCache.addVote(aggregateVote, stepDispatched)
-					a.internalCoreCh <- eventer(aggregateVote, nil, a.backend.Address(), false).(events.MessageEventer)
-					a.internalFdCh <- eventer(aggregateVote, nil, a.backend.Address(), false).(events.MessageEventer)
-				}
-			default:
-				a.logger.Crit("messages being aggregated are not votes", "type", reflect.TypeOf(validVotes[0]))
-			}
-		}
+		candidates = append(candidates, event)
+		publicKeys = append(publicKeys, publicKey)
+		signatures = append(signatures, signature)
+	}
 
-		// disconnect validators who sent us invalid votes at p2p layer and ignore the msgs coming from them
+	if len(candidates) == 0 {
+		return
+	}
+
+	hash := batch[0].Message.SignatureInput()
+	if blst.FastAggregateVerifyBatch(signatures, publicKeys, hash) {
+		// all signatures are valid
+		validVotes := make([]message.Vote, len(candidates))
+		for i, event := range candidates {
+			validVotes[i] = event.Message.(message.Vote)
+		}
+		a.aggregateAndDispatch(validVotes, eventer)
+		return
+	}
+
+	// at least one of the signatures is invalid, find at which index
+	invalids := blst.FindInvalid(signatures, publicKeys, hash)
+	defer func() {
 		if metrics.Enabled {
 			InvalidBg.Add(int64(len(invalids)))
 		}
-		for _, index := range invalids {
-			a.logger.Info("Received invalid bls signature from", "peer", batch[index].Sender)
-			a.handleInvalidMessage(batch[index].ErrCh, message.ErrBadSignature, batch[index].Sender)
+	}()
+	invalidSet := make(map[int]struct{}, len(invalids))
+	for _, idx := range invalids {
+		invalidSet[int(idx)] = struct{}{} // #nosec
+	}
+	validVotes := make([]message.Vote, 0, len(candidates)-len(invalids))
+	for i, event := range candidates {
+		if _, isInvalid := invalidSet[i]; !isInvalid {
+			validVotes = append(validVotes, event.Message.(message.Vote))
+			continue
+		}
+		a.logger.Info("Received invalid bls signature from", "peer", event.Sender)
+		a.handleInvalidMessage(event.ErrCh, message.ErrBadSignature, event.Sender)
+		a.signerSetCache.invalidateVotes(event.Message.(message.Vote))
+	}
+	if len(invalids) > 0 {
+		a.reInjectFilteredMessages(batch[0].Message.(message.Vote))
+	}
+	a.aggregateAndDispatch(validVotes, eventer)
+}
+
+func (a *aggregator) reInjectFilteredMessages(vote message.Vote) {
+	filtered := a.signerSetCache.emptyFiltered(vote.H(), vote.R(), vote.Code(), vote.Value())
+	warned := false
+	for i, e := range filtered {
+		select {
+		case a.internalBacklogCh <- e:
+		default:
+			if !warned {
+				log.Warn("Aggregator backlog channel is full, dropping messages", "number of messages dropped", len(filtered)-i,
+					"height", vote.H(), "round", vote.R(), "code", vote.Code(), "value", vote.Value())
+				warned = true
+			}
 		}
 	}
-	a.logger.Debug("Aggregator processed messages", "processed", processed, "sent", sent)
+}
+
+func (a *aggregator) aggregateAndDispatch(validVotes []message.Vote, eventer eventBuilder) {
+	if len(validVotes) == 0 {
+		return
+	}
+	switch validVotes[0].(type) {
+	case *message.Prevote:
+		aggregateVotes := message.AggregatePrevotes(validVotes)
+		for _, aggregateVote := range aggregateVotes {
+			a.signerSetCache.addVote(aggregateVote, stepDispatched)
+			a.internalCoreCh <- eventer(aggregateVote, nil, a.backend.Address(), false).(events.MessageEventer)
+			a.internalFdCh <- eventer(aggregateVote, nil, a.backend.Address(), false).(events.MessageEventer)
+		}
+	case *message.Precommit:
+		aggregateVotes := message.AggregatePrecommits(validVotes)
+		for _, aggregateVote := range aggregateVotes {
+			a.signerSetCache.addVote(aggregateVote, stepDispatched)
+			a.internalCoreCh <- eventer(aggregateVote, nil, a.backend.Address(), false).(events.MessageEventer)
+			a.internalFdCh <- eventer(aggregateVote, nil, a.backend.Address(), false).(events.MessageEventer)
+		}
+	default:
+		a.logger.Crit("messages being aggregated are not votes", "type", reflect.TypeOf(validVotes[0]))
+	}
 }
 
 func (a *aggregator) processProposal(proposalEvent events.UnverifiedMessageEvent, eventer eventBuilder) {
@@ -519,6 +522,8 @@ func (a *aggregator) handleVote(voteEvent events.UnverifiedMessageEvent, committ
 			return
 		}
 	}
+	// blocking call to trigger lazy computations of signatures and pubkeys
+	a.computeWorkers <- voteEvent
 }
 
 func (a *aggregator) toSkip(msg message.Msg) bool {

--- a/consensus/tendermint/backend/aggregator_cache.go
+++ b/consensus/tendermint/backend/aggregator_cache.go
@@ -159,8 +159,8 @@ type filteredCacheKey struct {
 }
 
 type aggregatorCache struct {
-	committeePowers map[uint64][]*big.Int              // the committee size used to create the bitmaps
-	voteCaches      map[uint8]map[cacheStep]*voteCache // code -> step -> vote cache
+	committeePowers map[uint64][]*big.Int   // the committee size used to create the bitmaps
+	voteCaches      map[uint8][2]*voteCache // code -> step -> vote cache
 
 	filterMu sync.RWMutex
 	filtered map[uint64]map[filteredCacheKey][]events.UnverifiedMessageEvent
@@ -169,7 +169,7 @@ type aggregatorCache struct {
 func newAggregatorCache() *aggregatorCache {
 	return &aggregatorCache{
 		committeePowers: make(map[uint64][]*big.Int),
-		voteCaches: map[uint8]map[cacheStep]*voteCache{
+		voteCaches: map[uint8][2]*voteCache{
 			message.PrecommitCode: {
 				stepReceived:   newVoteCache(),
 				stepDispatched: newVoteCache(),

--- a/consensus/tendermint/backend/aggregator_test.go
+++ b/consensus/tendermint/backend/aggregator_test.go
@@ -1161,8 +1161,8 @@ func TestAggregatorProcess(t *testing.T) {
 			makeBogusEvent(prevoteDec), // INVALID
 		})
 
-		a.processBatches(batches, func(m message.Msg, ev events.UnverifiedMessageEvent, _ bool) interface{} {
-			return currentHeightEventBuilder(m, ev, false)
+		a.processBatches(batches, func(m message.Msg, errCh chan<- error, sender common.Address, _ bool) interface{} {
+			return currentHeightEventBuilder(m, errCh, sender, false)
 		})
 
 		roundInfo := a.messages[h][r]

--- a/consensus/tendermint/backend/aggregator_test.go
+++ b/consensus/tendermint/backend/aggregator_test.go
@@ -399,6 +399,53 @@ func TestAggregatorMessageHandling(t *testing.T) {
 	})
 }
 
+func TestSignerJailed(t *testing.T) {
+	h := uint64(0)
+	r := int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	coreMock := interfaces.NewMockCore(ctrl)
+	backendMock := interfaces.NewMockBackend(ctrl)
+
+	backendMock.EXPECT().CommitteeByHeight(gomock.Any()).Return(committee, nil).Times(2)
+	coreMock.EXPECT().Height().Return(new(big.Int).SetUint64(h)).Times(2)
+	coreMock.EXPECT().Round().Return(r).Times(1)
+	backendMock.EXPECT().JailedCount().Return(1).Times(1)
+	backendMock.EXPECT().IsJailed(testCommitteeMember.Address).Return(true).Times(1)
+
+	a := &aggregator{
+		messages:       make(map[uint64]map[int64]*RoundInfo),
+		messagesFrom:   make(map[common.Address][]common.Hash),
+		core:           coreMock,
+		backend:        backendMock,
+		logger:         log.Root(),
+		signerSetCache: newAggregatorCache(),
+		computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+	}
+
+	value := common.Hash{0xca, 0xfe}
+	prevote := message.NewPrevote(r, h, value, testSigner, testCommitteeMember, committee)
+
+	a.handleEvent(makeBogusEvent(prevote))
+
+	roundInfo := a.messages[h][r]
+	require.Nil(t, roundInfo, "vote from jailed signer should not be saved and ignored")
+
+	precommit := message.NewPrecommit(r, h, value, testSigner, &committee.Members[1], committee)
+	precommit.Signers().AddSigner(2)
+	backendMock.EXPECT().IsJailed(committee.Members[1].Address).Return(false).Times(1)
+	backendMock.EXPECT().IsJailed(committee.Members[2].Address).Return(true).Times(1)
+	backendMock.EXPECT().JailedCount().Return(2).Times(1)
+
+	a.handleEvent(makeBogusEvent(precommit))
+	roundInfo = a.messages[h][r]
+	require.NotNil(t, roundInfo, "vote from an aggregate signer including at least one non jailed signer should be saved ")
+	require.Equal(t, 1, len(roundInfo.precommits[value]))
+	require.Equal(t, precommit.Hash(), roundInfo.precommits[value][0].Message.Hash())
+}
+
 // old height messages should be buffered and processed periodically
 func TestAggregatorOldHeightMessage(t *testing.T) {
 	t.Run("Old height messages are buffered as stale", func(t *testing.T) {

--- a/consensus/tendermint/backend/aggregator_test.go
+++ b/consensus/tendermint/backend/aggregator_test.go
@@ -1446,7 +1446,7 @@ func TestAggregatorDosProtection(t *testing.T) {
 
 	// mark msg from 0 as invalid
 	errCh := make(chan error, 1)
-	event := events.UnverifiedMessageEvent{Message: vote, ErrCh: errCh, Sender: zeroAddress, Posted: time.Now()}
+	event := events.UnverifiedMessageEvent{Message: votesFromZero[2], ErrCh: errCh, Sender: zeroAddress, Posted: time.Now()}
 	a.handleInvalidMessage(event, message.ErrBadSignature)
 	require.Equal(t, message.ErrBadSignature, <-errCh)
 	require.Equal(t, len(votesFromZero), len(a.toIgnore))

--- a/consensus/tendermint/backend/aggregator_test.go
+++ b/consensus/tendermint/backend/aggregator_test.go
@@ -163,6 +163,7 @@ func TestAggregatorStartAndStop(t *testing.T) {
 	require.NotNil(t, backend.aggregator.internalCoreCh)
 	require.NotNil(t, backend.aggregator.internalFdCh)
 	require.NotNil(t, backend.aggregator.internalBacklogCh)
+	require.NotNil(t, backend.aggregator.computeWorkersCh)
 	time.Sleep(1 * time.Second)
 	require.NoError(t, backend.Close())
 	ctx, cancel := context.WithCancel(context.Background())
@@ -229,13 +230,13 @@ func TestAggregatorMessageHandling(t *testing.T) {
 		coreMock.EXPECT().Round().Return(r).Times(1)
 
 		a := &aggregator{
-			messages:       make(map[uint64]map[int64]*RoundInfo),
-			messagesFrom:   make(map[common.Address][]common.Hash),
-			core:           coreMock,
-			backend:        backendMock,
-			logger:         log.Root(),
-			signerSetCache: newAggregatorCache(),
-			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+			messages:         make(map[uint64]map[int64]*RoundInfo),
+			messagesFrom:     make(map[common.Address][]common.Hash),
+			core:             coreMock,
+			backend:          backendMock,
+			logger:           log.Root(),
+			signerSetCache:   newAggregatorCache(),
+			computeWorkersCh: make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		value := common.Hash{0xca, 0xfe}
@@ -421,13 +422,13 @@ func TestSignerJailed(t *testing.T) {
 	backendMock.EXPECT().IsJailed(testCommitteeMember.Address).Return(true).Times(1)
 
 	a := &aggregator{
-		messages:       make(map[uint64]map[int64]*RoundInfo),
-		messagesFrom:   make(map[common.Address][]common.Hash),
-		core:           coreMock,
-		backend:        backendMock,
-		logger:         log.Root(),
-		signerSetCache: newAggregatorCache(),
-		computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+		messages:         make(map[uint64]map[int64]*RoundInfo),
+		messagesFrom:     make(map[common.Address][]common.Hash),
+		core:             coreMock,
+		backend:          backendMock,
+		logger:           log.Root(),
+		signerSetCache:   newAggregatorCache(),
+		computeWorkersCh: make(chan events.UnverifiedMessageEvent, 100),
 	}
 
 	value := common.Hash{0xca, 0xfe}
@@ -466,13 +467,13 @@ func TestAggregatorOldHeightMessage(t *testing.T) {
 		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 
 		a := &aggregator{
-			staleMessages:  make(map[common.Hash][]events.UnverifiedMessageEvent),
-			messagesFrom:   make(map[common.Address][]common.Hash),
-			core:           coreMock,
-			backend:        backendMock,
-			logger:         log.Root(),
-			signerSetCache: newAggregatorCache(),
-			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+			staleMessages:    make(map[common.Hash][]events.UnverifiedMessageEvent),
+			messagesFrom:     make(map[common.Address][]common.Hash),
+			core:             coreMock,
+			backend:          backendMock,
+			logger:           log.Root(),
+			signerSetCache:   newAggregatorCache(),
+			computeWorkersCh: make(chan events.UnverifiedMessageEvent, 100),
 		}
 		prevote := message.NewPrevote(0, h-2, common.Hash{0xca, 0xfe}, testSigner, testCommitteeMember, committee)
 
@@ -524,7 +525,7 @@ func TestAggregatorOldHeightMessage(t *testing.T) {
 func TestAggregatorSaveMessage(t *testing.T) {
 	t.Run("Save prevote", func(t *testing.T) {
 		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo),
-			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh: make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		r := int64(5)
@@ -543,7 +544,7 @@ func TestAggregatorSaveMessage(t *testing.T) {
 	})
 	t.Run("Save precommit", func(t *testing.T) {
 		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo),
-			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh: make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		r := int64(5)
@@ -562,7 +563,7 @@ func TestAggregatorSaveMessage(t *testing.T) {
 	})
 	t.Run("Save multiple message (individual and aggregates)", func(t *testing.T) {
 		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo),
-			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh: make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		r := int64(4)
@@ -646,7 +647,7 @@ func TestAggregatorHandleVote(t *testing.T) {
 		internalCoreCh:    make(chan events.MessageEventer, 10),
 		internalFdCh:      make(chan events.MessageEventer, 10),
 		internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
-		computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+		computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 100),
 	}
 
 	t.Run("equivocated votes dont trigger processing", func(t *testing.T) {
@@ -870,11 +871,11 @@ func TestAggregatorProcess(t *testing.T) {
 		backendMock := interfaces.NewMockBackend(ctrl)
 
 		a := &aggregator{
-			backend:        backendMock,
-			internalFdCh:   make(chan events.MessageEventer, 1),
-			internalCoreCh: make(chan events.MessageEventer, 1),
-			signerSetCache: newAggregatorCache(),
-			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+			backend:          backendMock,
+			internalFdCh:     make(chan events.MessageEventer, 1),
+			internalCoreCh:   make(chan events.MessageEventer, 1),
+			signerSetCache:   newAggregatorCache(),
+			computeWorkersCh: make(chan events.UnverifiedMessageEvent, 100),
 		}
 		a.DispatchCoreEvents(context.Background())
 		backendMock.EXPECT().DispatchToCore(gomock.Any()).Times(1)
@@ -902,7 +903,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
-			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		for _, message := range messages {
@@ -936,7 +937,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
-			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		for _, message := range messages {
@@ -968,7 +969,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
-			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		for _, message := range messages {
@@ -999,7 +1000,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalCoreCh:    make(chan events.MessageEventer),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
 			logger:            log.Root(),
-			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 100),
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1052,7 +1053,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
-			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 100),
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1123,7 +1124,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
-			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+			computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 100),
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1445,7 +1446,8 @@ func TestAggregatorDosProtection(t *testing.T) {
 
 	// mark msg from 0 as invalid
 	errCh := make(chan error, 1)
-	a.handleInvalidMessage(errCh, message.ErrBadSignature, zeroAddress)
+	event := events.UnverifiedMessageEvent{Message: vote, ErrCh: errCh, Sender: zeroAddress, Posted: time.Now()}
+	a.handleInvalidMessage(event, message.ErrBadSignature)
 	require.Equal(t, message.ErrBadSignature, <-errCh)
 	require.Equal(t, len(votesFromZero), len(a.toIgnore))
 
@@ -1511,7 +1513,7 @@ func setupTestAggregator(t *testing.T) (
 		internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
 		signerSetCache:    newAggregatorCache(),
 		toIgnore:          make(map[common.Hash]struct{}),
-		computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+		computeWorkersCh:  make(chan events.UnverifiedMessageEvent, 100),
 	}
 	aggregatorMsgChan := make(chan events.UnverifiedMessageEvent, 10)
 

--- a/consensus/tendermint/backend/aggregator_test.go
+++ b/consensus/tendermint/backend/aggregator_test.go
@@ -1,7 +1,9 @@
 package backend
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
@@ -23,6 +25,8 @@ import (
 	"github.com/autonity/autonity/crypto/blst"
 	"github.com/autonity/autonity/internal/testrand"
 	"github.com/autonity/autonity/log"
+	"github.com/autonity/autonity/p2p"
+	"github.com/autonity/autonity/rlp"
 )
 
 var (
@@ -221,6 +225,7 @@ func TestAggregatorMessageHandling(t *testing.T) {
 
 		backendMock.EXPECT().CommitteeByHeight(gomock.Any()).Return(committee, nil).Times(1)
 		coreMock.EXPECT().Height().Return(new(big.Int).SetUint64(h)).Times(1)
+		backendMock.EXPECT().JailedCount().Return(0).Times(1)
 		coreMock.EXPECT().Round().Return(r).Times(1)
 
 		a := &aggregator{
@@ -458,6 +463,7 @@ func TestAggregatorOldHeightMessage(t *testing.T) {
 
 		backendMock := interfaces.NewMockBackend(ctrl)
 		backendMock.EXPECT().CommitteeByHeight(gomock.Any()).Return(committee, nil).AnyTimes()
+		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 
 		a := &aggregator{
 			staleMessages:  make(map[common.Hash][]events.UnverifiedMessageEvent),
@@ -671,6 +677,7 @@ func TestAggregatorHandleVote(t *testing.T) {
 		voteBEvent := makeBogusEvent(voteB)
 
 		backendMock.EXPECT().DispatchToCore(gomock.Any()).Times(0)
+		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 
 		a.signerSetCache.addVote(voteA, stepReceived)
 		a.handleVote(voteAEvent, committee)
@@ -697,6 +704,7 @@ func TestAggregatorHandleVote(t *testing.T) {
 		a.signerSetCache.markCommittee(h, committee)
 
 		backendMock.EXPECT().Address().Return(testAddress).AnyTimes()
+		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 
 		singleVote := message.NewPrecommit(r, h, value, testSigner, &committee.Members[0], committee)
 		singleVote.Signers().AddSigner(0)
@@ -738,6 +746,7 @@ func TestAggregatorHandleVote(t *testing.T) {
 		a.signerSetCache.markCommittee(h, committee)
 
 		backendMock.EXPECT().Address().Return(testAddress).AnyTimes()
+		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 
 		voteA := message.NewPrecommit(r, h, value, testSigner, &committee.Members[0], committee)
 		voteA.Signers().AddSigner(0)
@@ -776,6 +785,7 @@ func TestAggregatorHandleVote(t *testing.T) {
 		a.signerSetCache.markCommittee(h, committee)
 
 		backendMock.EXPECT().Address().Return(testAddress).AnyTimes()
+		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 		voteA := message.NewPrecommit(r, h, v, testSigner, &committee.Members[0], committee)
 		voteA.Signers().AddSigner(0)
 		voteA.Signers().AddSigner(1)
@@ -817,6 +827,7 @@ func TestAggregatorHandleVote(t *testing.T) {
 		a.signerSetCache.markCommittee(h, committee)
 
 		backendMock.EXPECT().Address().Return(testAddress).AnyTimes()
+		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 		voteA := message.NewPrecommit(r, h, v, testSigner, &committee.Members[0], committee)
 		voteA.Signers().AddSigner(0)
 		voteA.Signers().AddSigner(1)
@@ -1095,6 +1106,68 @@ func TestAggregatorProcess(t *testing.T) {
 			return currentHeightEventBuilder(m, errCh, sender, false)
 		})
 	})
+	t.Run("ProcessBatch detects signature decode failures", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer waitForExpects(t, ctrl)
+
+		backendMock := interfaces.NewMockBackend(ctrl)
+
+		backendMock.EXPECT().DispatchToFD(gomock.Any()).AnyTimes()
+		backendMock.EXPECT().DispatchToCore(gomock.Any()).AnyTimes()
+		backendMock.EXPECT().Address().Return(testAddress).AnyTimes()
+
+		a := &aggregator{
+			backend:           backendMock,
+			logger:            log.Root(),
+			signerSetCache:    newAggregatorCache(),
+			internalFdCh:      make(chan events.MessageEventer, 10),
+			internalCoreCh:    make(chan events.MessageEventer, 10),
+			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
+			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		a.DispatchCoreEvents(ctx)
+		a.DispatchFaultDetectorEvents(ctx)
+		a.signerSetCache.markCommittee(h, committee)
+
+		var batches [][]events.UnverifiedMessageEvent
+		prevote := message.NewPrevote(r, h, value, testSigner, testCommitteeMember, committee)
+
+		// invalid signature data
+		var fs [96]byte
+		_, err := rand.Read(fs[:])
+		require.NoError(t, err)
+		payload, _ := rlp.EncodeToBytes([]any{
+			prevote.Code(),
+			uint64(r),
+			h,
+			prevote.Value(),
+			prevote.Signers().Copy(),
+			fs, // invalid signature
+		})
+		reader := bytes.NewReader(payload)
+		size := len(payload)
+		p2pPrevote := p2p.Msg{Code: 0x12, Size: uint32(size), Payload: reader}
+
+		prevoteDec := new(message.Prevote)
+		s := rlp.NewStream(p2pPrevote.Payload, uint64(size))
+		if err := prevoteDec.DecodeRLP(s); err != nil {
+			t.Fatal("failed prevote decoding: ", err)
+		}
+
+		require.NoError(t, prevoteDec.PreValidate(committee, true))
+		batches = append(batches, []events.UnverifiedMessageEvent{
+			makeBogusEvent(prevoteDec), // INVALID
+		})
+
+		a.processBatches(batches, func(m message.Msg, ev events.UnverifiedMessageEvent, _ bool) interface{} {
+			return currentHeightEventBuilder(m, ev, false)
+		})
+
+		roundInfo := a.messages[h][r]
+		require.Nil(t, roundInfo, "vote with invalid signature should not be stored")
+	})
 }
 
 func TestAggregatorFullFlow(t *testing.T) {
@@ -1112,6 +1185,7 @@ func TestAggregatorFullFlow(t *testing.T) {
 		backendMock.EXPECT().DispatchToFD(gomock.Any()).MaxTimes(1)
 		coreMock.EXPECT().Height().Return(big.NewInt(int64(h))).AnyTimes()
 		coreMock.EXPECT().Round().Return(r).AnyTimes()
+		backendMock.EXPECT().JailedCount().Return(0).Times(1)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -1163,6 +1237,7 @@ func TestAggregatorFullFlow(t *testing.T) {
 		backendMock.EXPECT().DispatchToFD(gomock.Any()).MaxTimes(1)
 		coreMock.EXPECT().Height().Return(big.NewInt(int64(h))).AnyTimes()
 		coreMock.EXPECT().Round().Return(r).AnyTimes()
+		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -1221,6 +1296,7 @@ func TestAggregatorFullFlow(t *testing.T) {
 		backendMock.EXPECT().MinNonExpiredHeight(gomock.Any()).Return(uint64(0), nil).AnyTimes()
 		coreMock.EXPECT().Height().Return(big.NewInt(int64(h))).AnyTimes()
 		coreMock.EXPECT().Round().Return(r).AnyTimes()
+		backendMock.EXPECT().JailedCount().Return(0).AnyTimes()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/consensus/tendermint/backend/aggregator_test.go
+++ b/consensus/tendermint/backend/aggregator_test.go
@@ -74,17 +74,18 @@ func mineOneBlock(t *testing.T, chain *core.BlockChain, backend *Backend) {
 
 // changes the signer key exploiting the Fake object. Makes it possible to arbitrarily control the outcome of the verification.
 func tweakPrevote(prevote *message.Prevote, key blst.PublicKey) *message.Prevote {
-	return message.NewFakePrevote(message.Fake{
+	fake := message.Fake{
 		FakeValue:          prevote.Value(),
 		FakeSigners:        prevote.Signers().Copy(),
 		FakeRound:          uint64(prevote.R()),
 		FakeHeight:         prevote.H(),
 		FakeSignatureInput: prevote.SignatureInput(),
-		FakeSignature:      prevote.Signature(),
 		FakePayload:        prevote.Payload(),
 		FakeHash:           prevote.Hash(),
 		FakeSignerKey:      key,
-	})
+	}
+	fake.FakeSignature, _ = prevote.Signature()
+	return message.NewFakePrevote(fake)
 }
 
 // waits for the condition function to be true, re-checking based on a ticker duration.
@@ -229,6 +230,7 @@ func TestAggregatorMessageHandling(t *testing.T) {
 			backend:        backendMock,
 			logger:         log.Root(),
 			signerSetCache: newAggregatorCache(),
+			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		value := common.Hash{0xca, 0xfe}
@@ -417,6 +419,7 @@ func TestAggregatorOldHeightMessage(t *testing.T) {
 			backend:        backendMock,
 			logger:         log.Root(),
 			signerSetCache: newAggregatorCache(),
+			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
 		}
 		prevote := message.NewPrevote(0, h-2, common.Hash{0xca, 0xfe}, testSigner, testCommitteeMember, committee)
 
@@ -467,7 +470,9 @@ func TestAggregatorOldHeightMessage(t *testing.T) {
 
 func TestAggregatorSaveMessage(t *testing.T) {
 	t.Run("Save prevote", func(t *testing.T) {
-		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo)}
+		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo),
+			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+		}
 
 		r := int64(5)
 		h := uint64(0)
@@ -484,7 +489,9 @@ func TestAggregatorSaveMessage(t *testing.T) {
 		require.Equal(t, vote.Hash(), roundInfo.prevotes[value][0].Message.Hash())
 	})
 	t.Run("Save precommit", func(t *testing.T) {
-		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo)}
+		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo),
+			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+		}
 
 		r := int64(5)
 		h := uint64(0)
@@ -501,7 +508,9 @@ func TestAggregatorSaveMessage(t *testing.T) {
 		require.Equal(t, vote.Hash(), roundInfo.precommits[value][0].Message.Hash())
 	})
 	t.Run("Save multiple message (individual and aggregates)", func(t *testing.T) {
-		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo)}
+		a := &aggregator{messages: make(map[uint64]map[int64]*RoundInfo),
+			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
+		}
 
 		r := int64(4)
 		h := uint64(2)
@@ -584,6 +593,7 @@ func TestAggregatorHandleVote(t *testing.T) {
 		internalCoreCh:    make(chan events.MessageEventer, 10),
 		internalFdCh:      make(chan events.MessageEventer, 10),
 		internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
+		computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
 	}
 
 	t.Run("equivocated votes dont trigger processing", func(t *testing.T) {
@@ -806,6 +816,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:   make(chan events.MessageEventer, 1),
 			internalCoreCh: make(chan events.MessageEventer, 1),
 			signerSetCache: newAggregatorCache(),
+			computeWorkers: make(chan events.UnverifiedMessageEvent, 100),
 		}
 		a.DispatchCoreEvents(context.Background())
 		backendMock.EXPECT().DispatchToCore(gomock.Any()).Times(1)
@@ -833,6 +844,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
+			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		for _, message := range messages {
@@ -866,6 +878,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
+			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		for _, message := range messages {
@@ -897,6 +910,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
+			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
 		}
 
 		for _, message := range messages {
@@ -927,6 +941,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalCoreCh:    make(chan events.MessageEventer),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
 			logger:            log.Root(),
+			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -979,6 +994,7 @@ func TestAggregatorProcess(t *testing.T) {
 			internalFdCh:      make(chan events.MessageEventer, 10),
 			internalCoreCh:    make(chan events.MessageEventer, 10),
 			internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
+			computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1372,6 +1388,7 @@ func setupTestAggregator(t *testing.T) (
 		internalBacklogCh: make(chan events.UnverifiedMessageEvent, 10),
 		signerSetCache:    newAggregatorCache(),
 		toIgnore:          make(map[common.Hash]struct{}),
+		computeWorkers:    make(chan events.UnverifiedMessageEvent, 100),
 	}
 	aggregatorMsgChan := make(chan events.UnverifiedMessageEvent, 10)
 

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -44,6 +44,8 @@ const (
 	numBuckets = 5987
 	// max number of entries in each packet
 	numEntries = 10
+	// message
+	aggregatorMessageQueue = 5000
 )
 
 var (
@@ -77,7 +79,7 @@ func New(
 		vmConfig:            vmConfig,
 		MsgStore:            ms, //TODO: we use this only in tests, to easily reach the msg store when having a reference to the backend. It would be better to just have the `accountability` module as a part of the backend object.
 		askSyncRateLimiter:  helpers.NewTimeWindowLimiter(constants.AskSyncInterval, 2),
-		aggregatorMessageCh: make(chan events.UnverifiedMessageEvent, 5000),
+		aggregatorMessageCh: make(chan events.UnverifiedMessageEvent, AggregatorMessageQueue),
 		jailingCh:           make(chan common.Address, 1000),
 		afdDispatchCh:       afdDispatchCh, // to FD
 		jailed: jailed{

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -79,7 +79,7 @@ func New(
 		vmConfig:            vmConfig,
 		MsgStore:            ms, //TODO: we use this only in tests, to easily reach the msg store when having a reference to the backend. It would be better to just have the `accountability` module as a part of the backend object.
 		askSyncRateLimiter:  helpers.NewTimeWindowLimiter(constants.AskSyncInterval, 2),
-		aggregatorMessageCh: make(chan events.UnverifiedMessageEvent, AggregatorMessageQueue),
+		aggregatorMessageCh: make(chan events.UnverifiedMessageEvent, aggregatorMessageQueue),
 		jailingCh:           make(chan common.Address, 1000),
 		afdDispatchCh:       afdDispatchCh, // to FD
 		jailed: jailed{

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -416,8 +416,9 @@ func (sb *Backend) assembleActivityProof(h uint64, epochInfo *types.EpochInfo) (
 		sb.logger.Warn("Failed to provide activity valid activity proof as proposer, not enough voting power", "height", h, "targetHeight", targetHeight, "targetRound", targetRound, "power", aggregatePrecommit.Power(), "quorum", quorum)
 		return nil, 0, nil
 	}
+	sig, _ := aggregatePrecommit.Signature()
 
-	return types.NewAggregateSignature(aggregatePrecommit.Signature().(*blst.BlsSignature), aggregatePrecommit.Signers()), targetRound, nil
+	return types.NewAggregateSignature(sig.(*blst.BlsSignature), aggregatePrecommit.Signers()), targetRound, nil
 }
 
 // Finalize runs any post-transaction state modifications (e.g. block rewards)

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -760,3 +760,9 @@ func (sb *Backend) IsJailed(address common.Address) bool {
 	_, ok := sb.jailed.validators[address]
 	return ok
 }
+
+func (sb *Backend) JailedCount() int {
+	sb.jailed.RLock()
+	defer sb.jailed.RUnlock()
+	return len(sb.jailed.validators)
+}

--- a/consensus/tendermint/backend/engine_test.go
+++ b/consensus/tendermint/backend/engine_test.go
@@ -279,7 +279,11 @@ func addQuorumCertificate(chain *core.BlockChain, engine *Backend, b *types.Bloc
 
 	header := b.Header()
 	precommit := message.NewPrecommit(int64(header.Round), header.Number.Uint64(), header.Hash(), engine.Sign, self, info.Committee)
-	header.QuorumCertificate = types.NewAggregateSignature(precommit.Signature().(*blst.BlsSignature), precommit.Signers())
+	sig, err := precommit.Signature()
+	if err != nil {
+		panic(err)
+	}
+	header.QuorumCertificate = types.NewAggregateSignature(sig.(*blst.BlsSignature), precommit.Signers())
 	blockWithCertificate := b.WithSeal(header) // improper use, we use the WithSeal function to substitute the header with the one with quorumCertificate set
 	return blockWithCertificate, precommit
 }
@@ -971,7 +975,7 @@ func TestAssembleProof(t *testing.T) {
 			// add fake precommit with low voting power, to simulate not enough voting power to build activity proof
 			committee.Members[0].VotingPower = new(big.Int).SetUint64(0)
 			precommit := message.NewPrecommit(int64(header.Round), header.Number.Uint64(), header.Hash(), backend.Sign, self, committee)
-			precommitWithLowPower := message.NewFakePrecommit(message.Fake{
+			fake := message.Fake{
 				FakeCode:           message.PrecommitCode,
 				FakeRound:          uint64(precommit.R()),
 				FakeHeight:         precommit.H(),
@@ -979,10 +983,11 @@ func TestAssembleProof(t *testing.T) {
 				FakePayload:        precommit.Payload(),
 				FakeHash:           precommit.Hash(),
 				FakeSigners:        precommit.Signers(),
-				FakeSignature:      precommit.Signature(),
 				FakeSignatureInput: precommit.SignatureInput(),
 				FakeSignerKey:      precommit.SignerKey(),
-			})
+			}
+			fake.FakeSignature, _ = precommit.Signature()
+			precommitWithLowPower := message.NewFakePrecommit(fake)
 			backend.MsgStore.Save(precommitWithLowPower)
 		}
 

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -128,23 +127,19 @@ func handleConsensusMsg[T any, PT interface {
 	*T
 	message.Msg
 }](sb *Backend, sender common.Address, p2pMsg p2p.Msg, errCh chan<- error) (bool, error) {
-	// we type cast it to byte.Reader because that's the only reader
-	// type we expect here
-	bReader := p2pMsg.Payload.(*bytes.Reader)
-	hash, err := crypto.HashFromReader(bReader)
+	payload, err := io.ReadAll(p2pMsg.Payload)
 	if err != nil {
-		log.Error("Failed to hash payload", "error", err)
+		log.Error("Failed to read payload", "error", err)
 		return true, err
 	}
+
+	hash := crypto.Hash(payload)
 	TotalMessageReceivedBg.Mark(1)
 	if sb.knownMessages.Contains(hash) {
 		return true, nil
 	}
 
 	MessageProcessedBg.Mark(1)
-	bReader.Seek(0, io.SeekStart)
-	payload, _ := io.ReadAll(bReader)
-	p2pMsg.Payload = bytes.NewReader(payload)
 	if !sb.coreRunning.Load() {
 		sb.pendingMessages.Enqueue(UnhandledMsg{addr: sender, msg: p2pMsg})
 		return true, nil // return nil to avoid shutting down connection during block sync.
@@ -168,6 +163,7 @@ func handleConsensusMsg[T any, PT interface {
 
 	sb.knownMessages.Add(hash, true)
 	msg := PT(new(T))
+
 	if err := msg.DecodeRLPPayload(payload, hash); err != nil {
 		sb.logger.Error("Error decoding consensus message", "err", err)
 		return true, err
@@ -215,13 +211,12 @@ func (sb *Backend) handleDecodedMsg(msg message.Msg, errCh chan<- error, sender 
 	disseminated := false // unless proposal, messages are not early disseminated
 
 	// if the sender is jailed, discard its messages
-	switch m := msg.(type) {
-	case *message.Propose:
+	if msg.Code() == message.ProposalCode {
+		m := msg.(*message.Propose)
 		if sb.IsJailed(m.Signer()) {
 			sb.logger.Debug("Ignoring proposal from jailed validator", "address", m.Signer())
 			return true, ErrJailed
 		}
-
 		// early Validation for proposals, so we can forward them to other peers
 		if err := msg.Validate(); err != nil {
 			return true, err
@@ -232,9 +227,6 @@ func (sb *Backend) handleDecodedMsg(msg message.Msg, errCh chan<- error, sender 
 			go sb.Gossip(committee, msg, sender)
 			disseminated = true
 		}
-	case *message.Prevote, *message.Precommit:
-	default:
-		sb.logger.Crit("Tendermint backend processing unknown message")
 	}
 
 	sb.Post(events.UnverifiedMessageEvent{

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -168,7 +168,7 @@ func handleConsensusMsg[T any, PT interface {
 
 	sb.knownMessages.Add(hash, true)
 	msg := PT(new(T))
-	if err := msg.DecodeRLPPayload(msg.Payload(), hash); err != nil {
+	if err := msg.DecodeRLPPayload(payload, hash); err != nil {
 		sb.logger.Error("Error decoding consensus message", "err", err)
 		return true, err
 	}
@@ -233,19 +233,6 @@ func (sb *Backend) handleDecodedMsg(msg message.Msg, errCh chan<- error, sender 
 			disseminated = true
 		}
 	case *message.Prevote, *message.Precommit:
-		vote := m.(message.Vote)
-		allJailed := true
-		vote.Signers().ForEachDistinctSigner(func(signerIndex int) {
-			signer := committee.Members[signerIndex].Address
-			if !sb.IsJailed(signer) {
-				allJailed = false
-			}
-		})
-		// unless all signers are jailed, we still process aggregates
-		if allJailed {
-			sb.logger.Debug("Vote message contains only signatures from jailed validators, ignoring message", "signers", vote.Signers().String())
-			return true, ErrJailed
-		}
 	default:
 		sb.logger.Crit("Tendermint backend processing unknown message")
 	}

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -143,7 +143,8 @@ func handleConsensusMsg[T any, PT interface {
 
 	MessageProcessedBg.Mark(1)
 	bReader.Seek(0, io.SeekStart)
-	p2pMsg.Payload = bReader
+	payload, _ := io.ReadAll(bReader)
+	p2pMsg.Payload = bytes.NewReader(payload)
 	if !sb.coreRunning.Load() {
 		sb.pendingMessages.Enqueue(UnhandledMsg{addr: sender, msg: p2pMsg})
 		return true, nil // return nil to avoid shutting down connection during block sync.

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -141,6 +142,7 @@ func handleConsensusMsg[T any, PT interface {
 
 	MessageProcessedBg.Mark(1)
 	if !sb.coreRunning.Load() {
+		p2pMsg.Payload = bytes.NewReader(payload)
 		sb.pendingMessages.Enqueue(UnhandledMsg{addr: sender, msg: p2pMsg})
 		return true, nil // return nil to avoid shutting down connection during block sync.
 	}

--- a/consensus/tendermint/backend/handler.go
+++ b/consensus/tendermint/backend/handler.go
@@ -168,11 +168,10 @@ func handleConsensusMsg[T any, PT interface {
 
 	sb.knownMessages.Add(hash, true)
 	msg := PT(new(T))
-	if err := p2pMsg.Decode(msg); err != nil {
+	if err := msg.DecodeRLPPayload(msg.Payload(), hash); err != nil {
 		sb.logger.Error("Error decoding consensus message", "err", err)
 		return true, err
 	}
-
 	// if the message is for a future height wrt to consensus engine, buffer it
 	// it will be re-injected into the handleDecodedMsg function at the right height
 	// TODO: Due to a race condition a message that is considered as future could become current,

--- a/consensus/tendermint/backend/handler_norace_test.go
+++ b/consensus/tendermint/backend/handler_norace_test.go
@@ -59,7 +59,7 @@ func TestUnhandledMsgs(t *testing.T) {
 			}
 			var payload []byte
 			if err := savedMsg.(UnhandledMsg).msg.Decode(&payload); err != nil {
-				t.Fatalf("couldnt decode payload")
+				t.Fatalf("couldnt decode payload, err=%v", err)
 			}
 			expectedPayload := append(counter, []byte("data")...)
 			if !reflect.DeepEqual(addr, expectedAddr) || !bytes.Equal(payload, expectedPayload) {

--- a/consensus/tendermint/backend/handler_test.go
+++ b/consensus/tendermint/backend/handler_test.go
@@ -199,40 +199,6 @@ func makeMsg(msgcode uint64, data interface{}) p2p.Msg {
 	return p2p.Msg{Code: msgcode, Size: uint32(size), Payload: bytes.NewReader(buff.Bytes())}
 }
 
-func TestSignerJailed(t *testing.T) {
-	chain, backend, pkeys := newBlockChain(2)
-
-	member0 := chain.Genesis().Header().Epoch.Committee.Members[0]
-	member1 := chain.Genesis().Header().Epoch.Committee.Members[1]
-	com := chain.Genesis().Header().Epoch.Committee
-
-	// generate one msg
-	data := message.NewPrevote(0, 1, common.Hash{}, makeSigner(pkeys[0]), &member0, com)
-	msg := p2p.Msg{Code: message.PrevoteNetworkMsg, Size: uint32(len(data.Payload())), Payload: bytes.NewReader(data.Payload())} // #nosec
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	setupMocks(backend, ctrl, t)
-
-	backend.jailed.Lock()
-	backend.jailed.validators[member0.Address] = 0
-	backend.jailed.Unlock()
-
-	errCh := make(chan error, 1)
-	_, err := backend.HandleMsg(testAddress, msg, errCh)
-	require.Equal(t, ErrJailed, err)
-
-	// an aggregate containing Jailed and non-jailed validator should be processed successfully
-	p1 := message.NewPrevote(0, 1, common.Hash{0xca, 0xfe}, makeSigner(pkeys[0]), &member0, com)
-	p2 := message.NewPrevote(0, 1, common.Hash{0xca, 0xfe}, makeSigner(pkeys[1]), &member1, com)
-	data = message.AggregatePrevotes([]message.Vote{p1, p2})[0]
-	msg = p2p.Msg{Code: message.PrevoteNetworkMsg, Size: uint32(len(data.Payload())), Payload: bytes.NewReader(data.Payload())} // #nosec
-	errCh = make(chan error, 1)
-	_, err = backend.HandleMsg(testAddress, msg, errCh)
-	require.Equal(t, nil, err)
-	require.NoError(t, backend.Close())
-}
-
 func TestFutureHeightMessage(t *testing.T) {
 	t.Run("received future height message is buffered", func(t *testing.T) {
 		chain, backend, _ := newBlockChain(1)

--- a/consensus/tendermint/core/core.go
+++ b/consensus/tendermint/core/core.go
@@ -312,7 +312,8 @@ func (c *Core) Commit(ctx context.Context, round int64, messages *message.RoundM
 	c.logger.Debug("Committing a block", "hash", proposalHash, "number", proposal.Block().Number().Uint64())
 
 	precommitWithQuorum := messages.PrecommitFor(proposalHash)
-	quorumCertificate := types.NewAggregateSignature(precommitWithQuorum.Signature().(*blst.BlsSignature), precommitWithQuorum.Signers())
+	sig, _ := precommitWithQuorum.Signature()
+	quorumCertificate := types.NewAggregateSignature(sig.(*blst.BlsSignature), precommitWithQuorum.Signers())
 
 	if err := c.backend.Commit(proposal.Block(), round, quorumCertificate); err != nil {
 		c.logger.Error("failed to commit a block", "err", err)

--- a/consensus/tendermint/core/interfaces/core_backend.go
+++ b/consensus/tendermint/core/interfaces/core_backend.go
@@ -90,6 +90,9 @@ type Backend interface {
 	// IsJailed returns true if the address belongs to the jailed validator list.
 	IsJailed(address common.Address) bool
 
+	// JailedCount returns the size of the jailed validator list.
+	JailedCount() int
+
 	// Jail jails the offender up to the end of the epoch
 	Jail(offender common.Address)
 

--- a/consensus/tendermint/core/interfaces/core_backend_mock.go
+++ b/consensus/tendermint/core/interfaces/core_backend_mock.go
@@ -311,6 +311,20 @@ func (mr *MockBackendMockRecorder) Jail(offender any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jail", reflect.TypeOf((*MockBackend)(nil).Jail), offender)
 }
 
+// JailedCount mocks base method.
+func (m *MockBackend) JailedCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JailedCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// JailedCount indicates an expected call of JailedCount.
+func (mr *MockBackendMockRecorder) JailedCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JailedCount", reflect.TypeOf((*MockBackend)(nil).JailedCount))
+}
+
 // KnownMsgHash mocks base method.
 func (m *MockBackend) KnownMsgHash() []common.Hash {
 	m.ctrl.T.Helper()

--- a/consensus/tendermint/core/message/base.go
+++ b/consensus/tendermint/core/message/base.go
@@ -52,11 +52,6 @@ func (b *base) Hash() common.Hash {
 	return b.hash
 }
 
-func (b *base) SetPayloadAndHash(payload []byte, hash common.Hash) {
-	b.hash = hash
-	b.payload = payload
-}
-
 func (b *base) Validate() error {
 	if !b.preverified {
 		panic("Trying to verify a message that was not previously pre-verified")

--- a/consensus/tendermint/core/message/base.go
+++ b/consensus/tendermint/core/message/base.go
@@ -43,10 +43,6 @@ func (b *base) SignatureInput() common.Hash {
 	return b.signatureInput
 }
 
-func (b *base) Signature() blst.Signature {
-	return b.signature
-}
-
 func (b *base) Payload() []byte {
 	return b.payload
 }

--- a/consensus/tendermint/core/message/base.go
+++ b/consensus/tendermint/core/message/base.go
@@ -39,9 +39,6 @@ func (b *base) R() int64 {
 	return b.round
 }
 
-func (b *base) SignatureInput() common.Hash {
-	return b.signatureInput
-}
 
 func (b *base) Payload() []byte {
 	return b.payload

--- a/consensus/tendermint/core/message/base.go
+++ b/consensus/tendermint/core/message/base.go
@@ -10,17 +10,17 @@ import (
 
 type base struct {
 	// populated at decoding phase
-	height         uint64
-	round          int64
+	height      uint64
+	round       int64
+	payload     []byte
+	hash        common.Hash
+	verified    bool
+	preverified bool
+
+	// populated on demand for votes
+	signerKey      blst.PublicKey
 	signatureInput common.Hash
 	signature      blst.Signature
-	payload        []byte
-	hash           common.Hash
-	verified       bool
-	preverified    bool
-
-	// populated on demand
-	signerKey blst.PublicKey
 }
 
 func (b *base) Verified() bool {
@@ -39,7 +39,6 @@ func (b *base) R() int64 {
 	return b.round
 }
 
-
 func (b *base) Payload() []byte {
 	return b.payload
 }
@@ -51,6 +50,11 @@ func (b *base) EncodeRLP(w io.Writer) error {
 
 func (b *base) Hash() common.Hash {
 	return b.hash
+}
+
+func (b *base) SetPayloadAndHash(payload []byte, hash common.Hash) {
+	b.hash = hash
+	b.payload = payload
 }
 
 func (b *base) Validate() error {

--- a/consensus/tendermint/core/message/interfaces.go
+++ b/consensus/tendermint/core/message/interfaces.go
@@ -38,7 +38,7 @@ type Msg interface {
 	Payload() []byte
 
 	// Signature returns the signature of this message
-	Signature() blst.Signature
+	Signature() (blst.Signature, error)
 
 	// PreValidate attaches auxiliary information to the message (e.g. aggregated key and power)
 	// as the name suggests, it needs to be executed before validating the message

--- a/consensus/tendermint/core/message/interfaces.go
+++ b/consensus/tendermint/core/message/interfaces.go
@@ -37,7 +37,7 @@ type Msg interface {
 	// Payload returns the rlp-encoded payload ready to be broadcasted.
 	Payload() []byte
 
-	// Signature returns the signature of this message
+	// Signature returns the signature of this message, error is returned if the signature could not be decoded
 	Signature() (blst.Signature, error)
 
 	// PreValidate attaches auxiliary information to the message (e.g. aggregated key and power)

--- a/consensus/tendermint/core/message/interfaces.go
+++ b/consensus/tendermint/core/message/interfaces.go
@@ -59,6 +59,8 @@ type Msg interface {
 	Verified() bool
 
 	PreVerified() bool
+
+	DecodeRLPPayload(payload []byte, hash common.Hash) error
 }
 
 // Votes have an additional method, which returns all the available information about the signers

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -739,7 +739,7 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 		aggregateSigner := representative.Signers().Copy()
 		sig, err := representative.Signature()
 		if err != nil {
-			continue
+			panic(err) // we don't expect signature to be invalid at this point
 		}
 		signaturesToAggregate := []blst.Signature{sig}
 
@@ -755,7 +755,7 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 				aggregateSigner.Merge(otherVote.Signers())
 				otherVoteSig, err := otherVote.Signature()
 				if err != nil {
-					continue
+					panic(err) // we don't expect signature to be invalid at this point
 				}
 				signaturesToAggregate = append(signaturesToAggregate, otherVoteSig)
 			} else {

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -876,20 +876,18 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	}
 
 	// Coefficients (list of []byte)
-	var i, size uint64
-	if size, err = s.List(); err != nil {
+	if _, err = s.List(); err != nil {
 		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
-	// #nosec
-	if int(size) > types.MaxAllowedSigners {
-		return constants.ErrInvalidMessage
-	}
-
-	coefficients := make([]*big.Int, 0, size)
-	for i = 0; i < size; i++ { // coefficients list
+	coefficients := make([]*big.Int, 0, bitMapAsBig.BitLen())
+	for { // coefficients list
 		coefficient := new(big.Int)
-		if err := s.Decode(coefficient); err != nil {
+		err := s.Decode(coefficient)
+		if errors.Is(err, rlp.EOL) {
+			break
+		}
+		if err != nil {
 			return errors.Join(err, constants.ErrInvalidMessage)
 		}
 		coefficients = append(coefficients, coefficient)
@@ -1001,19 +999,18 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	}
 
 	// Coefficients (list of []byte)
-	var i, size uint64
-	if size, err = s.List(); err != nil {
+	if _, err = s.List(); err != nil {
 		return errors.Join(err, constants.ErrInvalidMessage)
 	}
-	// #nosec
-	if size > uint64(types.MaxAllowedSigners) {
-		return constants.ErrInvalidMessage
-	}
 
-	coefficients := make([]*big.Int, 0, size)
-	for i = 0; i < size; i++ { // coefficients list
+	coefficients := make([]*big.Int, 0, bitMapAsBig.BitLen())
+	for { // coefficients list
 		coefficient := new(big.Int)
-		if err := s.Decode(coefficient); err != nil {
+		err := s.Decode(coefficient)
+		if errors.Is(err, rlp.EOL) {
+			break
+		}
+		if err != nil {
 			return errors.Join(err, constants.ErrInvalidMessage)
 		}
 		coefficients = append(coefficients, coefficient)

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -250,6 +250,10 @@ func (p *Propose) SignerKey() blst.PublicKey {
 	return p.base.signerKey
 }
 
+func (p *Propose) Signature() (blst.Signature, error) {
+	return p.base.signature, nil
+}
+
 func (p *Propose) PreValidate(committee *types.Committee, _ bool) error {
 	if p.preverified {
 		return nil
@@ -314,6 +318,10 @@ func (p *LightProposal) SignerKey() blst.PublicKey {
 		panic("Trying to access signer key on not preverified message")
 	}
 	return p.base.signerKey
+}
+
+func (p *LightProposal) Signature() (blst.Signature, error) {
+	return p.base.signature, nil
 }
 
 func NewLightProposal(proposal *Propose) *LightProposal {
@@ -455,6 +463,25 @@ type vote struct {
 	signers *types.Signers
 	base
 	signerKeyOnce sync.Once `rlp:"-"` // ensures that the signerKey is computed only once
+
+	// signature caching
+	sigOnce        sync.Once `rlp:"-"`
+	sigErr         error     `rlp:"-"`
+	signatureBytes []byte    `rlp:"-"` // used for caching the raw sig bytes at decoding phase
+}
+
+func (v *vote) Signature() (blst.Signature, error) {
+	v.sigOnce.Do(func() {
+		if len(v.signatureBytes) == 0 {
+			return
+		}
+		v.base.signature, v.sigErr = blst.SignatureFromBytes(v.signatureBytes)
+		if v.sigErr == nil && v.signers.Len() == 1 && v.base.signature.IsZero() {
+			v.sigErr = ErrInvalidIndividualVote
+		}
+		v.signatureBytes = nil
+	})
+	return v.base.signature, v.sigErr
 }
 
 func (v *vote) SignerKey() blst.PublicKey {
@@ -501,9 +528,9 @@ func (v *vote) PreValidate(committee *types.Committee, shouldRespectCap bool) er
 	}
 
 	// if it is an individual signature, it cannot be 0
-	if v.signers.Len() == 1 && v.signature.IsZero() {
-		return ErrInvalidIndividualVote
-	}
+	//if v.signers.Len() == 1 && v.signature.IsZero() {
+	//	return ErrInvalidIndividualVote
+	//}
 
 	maxCoefficient := v.signers.MaxCoefficient()
 	if shouldRespectCap && maxCoefficient.BitLen() > common.VoteCap {
@@ -521,6 +548,11 @@ func (v *vote) PreValidate(committee *types.Committee, shouldRespectCap bool) er
 func (v *vote) Validate() error {
 	// loads Signer key if not already done
 	v.SignerKey()
+	// computes Signature if not already done
+	_, err := v.Signature()
+	if err != nil {
+		return err
+	}
 	return v.base.Validate()
 }
 
@@ -677,7 +709,11 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 	for len(votesToProcess) > 0 { // this loop should never run more than once, if there is no maxCoefficient cap breach
 		representative := votesToProcess[0]
 		aggregateSigner := representative.Signers().Copy()
-		signaturesToAggregate := []blst.Signature{representative.Signature()}
+		sig, err := representative.Signature()
+		if err != nil {
+			continue
+		}
+		signaturesToAggregate := []blst.Signature{sig}
 
 		var nextVotesToProcess []Vote
 		for _, otherVote := range votesToProcess[1:] {
@@ -689,7 +725,11 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 			// overlapping signers, we can aggregate them
 			if ignoreBoundaries || aggregateSigner.RespectsBoundaries(otherVote.Signers()) {
 				aggregateSigner.Merge(otherVote.Signers())
-				signaturesToAggregate = append(signaturesToAggregate, otherVote.Signature())
+				otherVoteSig, err := otherVote.Signature()
+				if err != nil {
+					continue
+				}
+				signaturesToAggregate = append(signaturesToAggregate, otherVoteSig)
 			} else {
 				// unmergeable due to coefficient cap breach, Rare case
 				nextVotesToProcess = append(nextVotesToProcess, otherVote)
@@ -739,6 +779,105 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 }
 
 func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
+	// Read the raw RLP payload from the stream.
+	payload, err := s.Raw()
+	if err != nil {
+		return err
+	}
+
+	// The RLP structure for a vote is a list of 6 items:
+	// [Code, Round, Height, Value, Signers, Signature]
+	var decoded []any
+	if err := rlp.DecodeBytes(payload, &decoded); err != nil {
+		return err
+	}
+
+	if len(decoded) != 6 {
+		return fmt.Errorf("invalid RLP for vote: expected 6 items, got %d", len(decoded))
+	}
+
+	// --- Field 1: Code ---
+	codeBytes, ok := decoded[0].([]uint8)
+	if !ok || len(codeBytes) != 1 || codeBytes[0] != PrevoteCode {
+		return constants.ErrInvalidMessage
+	}
+
+	// --- Field 2: Round ---
+	roundBytes, ok := decoded[1].([]uint8)
+	if !ok {
+		return constants.ErrInvalidMessage
+	}
+	round := new(big.Int).SetBytes(roundBytes).Uint64()
+	if round > constants.MaxRound {
+		return constants.ErrInvalidMessage
+	}
+	p.round = int64(round)
+
+	// --- Field 3: Height ---
+	heightBytes, ok := decoded[2].([]byte)
+	if !ok {
+		return constants.ErrInvalidMessage
+	}
+	height := new(big.Int).SetBytes(heightBytes).Uint64()
+	if height == 0 {
+		return constants.ErrInvalidMessage
+	}
+	p.height = height
+
+	// --- Field 4: hash ---
+	valueBytes, ok := decoded[3].([]byte)
+	if !ok {
+		return constants.ErrInvalidMessage
+	}
+	p.value = common.BytesToHash(valueBytes)
+
+	// --- Field 5: Signers ---
+	signersList, ok := decoded[4].([]any)
+	if !ok || len(signersList) != 2 {
+		return fmt.Errorf("invalid RLP for signers: expected a list of 2 items")
+	}
+
+	bitmap, okBitmap := signersList[0].([]byte)
+	coeffsList, okCoeffs := signersList[1].([]any)
+	if !okBitmap || !okCoeffs {
+		return fmt.Errorf("invalid RLP for signers: bitmap and coefficients must be byte slices")
+	}
+	coefficients := make([]*big.Int, len(coeffsList))
+	for i, item := range coeffsList {
+		coeffBytes, valid := item.([]byte)
+		if !valid {
+			return fmt.Errorf("invalid RLP for coefficient item: must be a byte slice")
+		}
+		coefficients[i] = new(big.Int).SetBytes(coeffBytes)
+	}
+	signers := &types.Signers{
+		Bitmap:       (*types.Bitmap)(new(big.Int).SetBytes(bitmap)),
+		Coefficients: coefficients,
+	}
+	if signers.SanityCheck() != nil {
+		return constants.ErrInvalidMessage
+	}
+	p.signers = signers
+
+	// --- Field 6: Signature ---
+	sigBytes, ok := decoded[5].([]byte)
+	if !ok {
+		return constants.ErrInvalidMessage
+	}
+	p.signatureBytes = sigBytes
+	// Set remaining base fields
+	//todo: defer signatureInput computation?
+	p.signatureInput = VoteSignatureInput(height, round, PrevoteCode, p.value)
+	// this hash may not be needed as this is computed in backend
+	p.hash = crypto.Hash(payload)
+	p.verified = false
+	p.preverified = false
+	p.payload = payload
+	return nil
+}
+
+/*
+func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
 	payload, err := s.Raw()
 	if err != nil {
 		return err
@@ -778,46 +917,104 @@ func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
 	p.verified = false
 	p.preverified = false
 	return nil
-}
+}*/
 
 func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
+	// Read the raw RLP payload from the stream.
 	payload, err := s.Raw()
 	if err != nil {
 		return err
 	}
-	encoded := &extVote{}
-	if err := rlp.DecodeBytes(payload, encoded); err != nil {
+
+	// The RLP structure for a vote is a list of 6 items:
+	// [Code, Round, Height, Value, Signers, Signature]
+	var decoded []any
+	if err := rlp.DecodeBytes(payload, &decoded); err != nil {
 		return err
 	}
-	if encoded.Code != PrecommitCode {
+
+	if len(decoded) != 6 {
+		return fmt.Errorf("invalid RLP for vote: expected 6 items, got %d", len(decoded))
+	}
+
+	// --- Field 1: Code ---
+	codeBytes, ok := decoded[0].([]uint8)
+	if !ok || len(codeBytes) != 1 || codeBytes[0] != PrecommitCode {
 		return constants.ErrInvalidMessage
 	}
-	if encoded.Signature == nil {
+
+	// --- Field 2: Round ---
+	roundBytes, ok := decoded[1].([]uint8)
+	if !ok {
 		return constants.ErrInvalidMessage
 	}
-	if encoded.Height == 0 {
+	round := new(big.Int).SetBytes(roundBytes).Uint64()
+	if round > constants.MaxRound {
 		return constants.ErrInvalidMessage
 	}
-	if encoded.Round > constants.MaxRound {
+	p.round = int64(round)
+
+	// --- Field 3: Height ---
+	heightBytes, ok := decoded[2].([]byte)
+	if !ok {
 		return constants.ErrInvalidMessage
 	}
-	if encoded.Signers == nil || encoded.Signers.Bitmap == nil || encoded.Signers.Coefficients == nil {
+	height := new(big.Int).SetBytes(heightBytes).Uint64()
+	if height == 0 {
 		return constants.ErrInvalidMessage
 	}
-	if encoded.Signers.SanityCheck() != nil {
+	p.height = height
+
+	// --- Field 4: hash ---
+	valueBytes, ok := decoded[3].([]byte)
+	if !ok {
 		return constants.ErrInvalidMessage
 	}
-	p.height = encoded.Height
-	p.round = int64(encoded.Round)
-	p.value = encoded.Value
-	p.signature = encoded.Signature
-	p.signers = encoded.Signers
-	p.payload = payload
-	// precompute hash and signature hash
-	p.signatureInput = VoteSignatureInput(encoded.Height, encoded.Round, PrecommitCode, encoded.Value)
+	p.value = common.BytesToHash(valueBytes)
+
+	// --- Field 5: Signers ---
+	signersList, ok := decoded[4].([]any)
+	if !ok || len(signersList) != 2 {
+		return fmt.Errorf("invalid RLP for signers: expected a list of 2 items")
+	}
+
+	bitmap, okBitmap := signersList[0].([]byte)
+	coeffsList, okCoeffs := signersList[1].([]any)
+	if !okBitmap || !okCoeffs {
+		return fmt.Errorf("invalid RLP for signers: bitmap and coefficients must be byte slices")
+	}
+	coefficients := make([]*big.Int, len(coeffsList))
+	for i, item := range coeffsList {
+		coeffBytes, valid := item.([]byte)
+		if !valid {
+			return fmt.Errorf("invalid RLP for coefficient item: must be a byte slice")
+		}
+		coefficients[i] = new(big.Int).SetBytes(coeffBytes)
+	}
+	signers := &types.Signers{
+		Bitmap:       (*types.Bitmap)(new(big.Int).SetBytes(bitmap)),
+		Coefficients: coefficients,
+	}
+	if signers.SanityCheck() != nil {
+		return constants.ErrInvalidMessage
+	}
+	p.signers = signers
+
+	// --- Field 6: Signature ---
+	sigBytes, ok := decoded[5].([]byte)
+	if !ok {
+		return constants.ErrInvalidMessage
+	}
+	p.signatureBytes = sigBytes
+	// Set remaining base fields
+	//todo: defer signatureInput computation?
+	p.signatureInput = VoteSignatureInput(height, round, PrecommitCode, p.value)
+	// this hash may not be needed as this is computed in backend
 	p.hash = crypto.Hash(payload)
+	p.payload = payload
 	p.verified = false
 	p.preverified = false
+
 	return nil
 }
 
@@ -894,7 +1091,7 @@ func (f Fake) Power() *big.Int                              { return f.FakePower
 func (f Fake) String() string                               { return "{fake}" }
 func (f Fake) Hash() common.Hash                            { return f.FakeHash }
 func (f Fake) Payload() []byte                              { return f.FakePayload }
-func (f Fake) Signature() blst.Signature                    { return f.FakeSignature }
+func (f Fake) Signature() (blst.Signature, error)           { return f.FakeSignature, nil }
 func (f Fake) PreValidate(_ *types.Committee, _ bool) error { return nil }
 func (f Fake) Validate() error                              { return nil }
 func (f Fake) SignatureInput() common.Hash                  { return f.FakeSignatureInput }

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -63,6 +63,12 @@ var NetworkCodes = map[uint8]uint64{
 	PrecommitCode: PrecommitNetworkMsg,
 }
 
+var rlpStreamPool = sync.Pool{
+	New: func() any {
+		return rlp.NewStream(bytes.NewBuffer(nil), 0)
+	},
+}
+
 type Signer func(hash common.Hash) blst.Signature
 
 // TODO: To save space we could send only the signer index instead of the signer address
@@ -175,6 +181,14 @@ func NewPropose(r int64, h uint64, vr int64, block *types.Block, signer Signer, 
 	}
 }
 
+func (p *Propose) DecodeRLP(s *rlp.Stream) error {
+	payload, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
+}
+
 func (p *Propose) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	ext := &extPropose{}
 	if err := rlp.DecodeBytes(payload, ext); err != nil {
@@ -223,22 +237,14 @@ func (p *Propose) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	p.block = ext.ProposalBlock
 	p.signer = ext.Signer
 	p.signature = ext.Signature
+	p.hash = hash
 	p.payload = payload
 	// precompute hash and signature hash
 	signaturePayload, _ := rlp.EncodeToBytes([]any{ProposalCode, ext.Round, ext.Height, ext.ValidRound, ext.IsValidRoundNil, p.block.Hash()})
 	p.signatureInput = crypto.Hash(signaturePayload)
-	p.hash = hash
 	p.verified = false
 	p.preverified = false
 	return nil
-}
-
-func (p *Propose) DecodeRLP(s *rlp.Stream) error {
-	payload, err := s.Raw()
-	if err != nil {
-		return err
-	}
-	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
 }
 
 func (p *Propose) Signer() common.Address {
@@ -379,8 +385,15 @@ func NewLightProposal(proposal *Propose) *LightProposal {
 	}
 }
 
-func (p *LightProposal) DecodeRLPPayload(payload []byte, hash common.Hash) error {
+func (p *LightProposal) DecodeRLP(s *rlp.Stream) error {
+	payload, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
+}
 
+func (p *LightProposal) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	ext := &extLightProposal{}
 	if err := rlp.DecodeBytes(payload, ext); err != nil {
 		return err
@@ -421,21 +434,13 @@ func (p *LightProposal) DecodeRLPPayload(payload []byte, hash common.Hash) error
 	p.signer = ext.Signer
 	p.signature = ext.Signature
 	p.payload = payload
+	p.hash = hash
 	// precompute hash and signature hash
 	signaturePayload, _ := rlp.EncodeToBytes([]any{ProposalCode, ext.Round, ext.Height, ext.ValidRound, ext.IsValidRoundNil, p.blockHash})
 	p.signatureInput = crypto.Hash(signaturePayload)
-	p.hash = hash
 	p.verified = false
 	p.preverified = false
 	return nil
-}
-
-func (p *LightProposal) DecodeRLP(s *rlp.Stream) error {
-	payload, err := s.Raw()
-	if err != nil {
-		return err
-	}
-	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
 }
 
 func (p *LightProposal) Signer() common.Address {
@@ -484,11 +489,11 @@ type vote struct {
 	base
 
 	// signature caching
-	signerKeyOnce      sync.Once `rlp:"-"` // ensures that the signerKey is computed only once
-	sigOnce            sync.Once `rlp:"-"`
-	sigErr             error     `rlp:"-"`
-	signatureBytes     []byte    `rlp:"-"` // used for caching the raw sig bytes at decoding phase
-	signatureInputOnce sync.Once `rlp:"-"`
+	signerKeyOnce      sync.Once // ensures that the signerKey is computed only once
+	sigOnce            sync.Once
+	sigErr             error
+	signatureBytes     []byte // used for caching the raw sig bytes at decoding phase
+	signatureInputOnce sync.Once
 }
 
 func (v *vote) SignatureInput() common.Hash {
@@ -503,6 +508,9 @@ func (v *vote) Value() common.Hash {
 }
 
 func (v *vote) Signature() (blst.Signature, error) {
+	if !v.preverified {
+		panic("Trying to access signature on not preverified message")
+	}
 	v.sigOnce.Do(func() {
 		if len(v.signatureBytes) == 0 {
 			return
@@ -799,9 +807,18 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 	return results
 }
 
+func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
+	payload, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
+}
+
 func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
-	var s rlp.Stream
+	s := rlpStreamPool.Get().(*rlp.Stream)
 	s.Reset(bytes.NewReader(payload), uint64(len(payload)))
+	defer rlpStreamPool.Put(s)
 
 	if _, err := s.List(); err != nil { // Begin decoding list
 		return constants.ErrInvalidMessage
@@ -810,7 +827,7 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 1: Code
 	code, err := s.Uint()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if code != uint64(PrevoteCode) {
 		return constants.ErrInvalidMessage
@@ -819,7 +836,7 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 2: Round
 	round, err := s.Uint()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if round > constants.MaxRound {
 		return constants.ErrInvalidMessage
@@ -829,7 +846,7 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 3: Height (uint64)
 	height, err := s.Uint()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if height == 0 {
 		return constants.ErrInvalidMessage
@@ -839,7 +856,7 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 4: Value (32 bytes)
 	valueBytes, err := s.Bytes()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if len(valueBytes) != common.HashLength {
 		return constants.ErrInvalidMessage
@@ -848,37 +865,43 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 
 	// Field 5: Signers (nested list [Bitmap bytes, Coefficients list])
 	if _, err := s.List(); err != nil { // Begin signers list
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
 	// Bitmap ([]byte)
 	bitmap, err := s.Bytes()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
 	// Coefficients (list of []byte)
-	if _, err := s.List(); err != nil {
-		return err
+	var i, size uint64
+	if size, err = s.List(); err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
-	var coefficients []*big.Int
-	for { // coefficients list
+	// #nosec
+	if int(size) > types.MaxAllowedSigners {
+		return constants.ErrInvalidMessage
+	}
+
+	coefficients := make([]*big.Int, 0, size)
+	for i = 0; i < size; i++ { // coefficients list
 		coeffBytes, err := s.Bytes()
 		if errors.Is(err, rlp.EOL) {
 			break
 		}
 		if err != nil {
-			return err
+			return errors.Join(err, constants.ErrInvalidMessage)
 		}
 		coefficients = append(coefficients, new(big.Int).SetBytes(coeffBytes))
 	}
 
 	if err := s.ListEnd(); err != nil { // End coefficients list
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if err := s.ListEnd(); err != nil { // End signers list
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
 	p.signers = &types.Signers{
@@ -892,24 +915,26 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 6: Signature ([]byte)
 	sigBytes, err := s.Bytes()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	if len(sigBytes) != blst.BLSSignatureLength {
+		return constants.ErrInvalidMessage
 	}
 	p.signatureBytes = sigBytes
 
 	if err := s.ListEnd(); err != nil { // End outer list
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
+	p.payload = payload
 	p.hash = hash
 	p.code = PrevoteCode
 	p.verified = false
 	p.preverified = false
-	p.payload = payload
 	return nil
 }
 
-func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
-	// Read the raw RLP payload from the stream.
+func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
 	payload, err := s.Raw()
 	if err != nil {
 		return err
@@ -918,8 +943,9 @@ func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
 }
 
 func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
-	var s rlp.Stream
+	s := rlpStreamPool.Get().(*rlp.Stream)
 	s.Reset(bytes.NewReader(payload), uint64(len(payload)))
+	defer rlpStreamPool.Put(s)
 
 	if _, err := s.List(); err != nil { // Begin decoding list
 		return constants.ErrInvalidMessage
@@ -928,7 +954,7 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 1: Code
 	code, err := s.Uint()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if code != uint64(PrecommitCode) {
 		return constants.ErrInvalidMessage
@@ -937,7 +963,7 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 2: Round
 	round, err := s.Uint()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if round > constants.MaxRound {
 		return constants.ErrInvalidMessage
@@ -947,7 +973,7 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 3: Height (uint64)
 	height, err := s.Uint()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if height == 0 {
 		return constants.ErrInvalidMessage
@@ -957,7 +983,7 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 4: Value (32 bytes)
 	valueBytes, err := s.Bytes()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if len(valueBytes) != common.HashLength {
 		return constants.ErrInvalidMessage
@@ -966,37 +992,42 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 
 	// Field 5: Signers (nested list [Bitmap bytes, Coefficients list])
 	if _, err := s.List(); err != nil { // Begin signers list
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
 	// Bitmap ([]byte)
 	bitmap, err := s.Bytes()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
 	// Coefficients (list of []byte)
-	if _, err := s.List(); err != nil {
-		return err
+	var i, size uint64
+	if size, err = s.List(); err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	// #nosec
+	if size > uint64(types.MaxAllowedSigners) {
+		return constants.ErrInvalidMessage
 	}
 
-	var coefficients []*big.Int
-	for { // coefficients list
+	coefficients := make([]*big.Int, 0, size)
+	for i = 0; i < size; i++ { // coefficients list
 		coeffBytes, err := s.Bytes()
 		if errors.Is(err, rlp.EOL) {
 			break
 		}
 		if err != nil {
-			return err
+			return errors.Join(err, constants.ErrInvalidMessage)
 		}
 		coefficients = append(coefficients, new(big.Int).SetBytes(coeffBytes))
 	}
 
 	if err := s.ListEnd(); err != nil { // End coefficients list
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 	if err := s.ListEnd(); err != nil { // End signers list
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
 	p.signers = &types.Signers{
@@ -1010,29 +1041,23 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// Field 6: Signature ([]byte)
 	sigBytes, err := s.Bytes()
 	if err != nil {
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	if len(sigBytes) != blst.BLSSignatureLength {
+		return constants.ErrInvalidMessage
 	}
 	p.signatureBytes = sigBytes
 
 	if err := s.ListEnd(); err != nil { // End outer list
-		return err
+		return errors.Join(err, constants.ErrInvalidMessage)
 	}
 
+	p.payload = payload
 	p.hash = hash
 	p.code = PrecommitCode
 	p.verified = false
 	p.preverified = false
-	p.payload = payload
 	return nil
-}
-
-func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
-	// Read the raw RLP payload from the stream.
-	payload, err := s.Raw()
-	if err != nil {
-		return err
-	}
-	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
 }
 
 func VoteSignatureInput(h uint64, r uint64, code uint8, v common.Hash) common.Hash {

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -614,7 +614,7 @@ func (v *vote) decodeRLPPayload(code uint8, payload []byte, hash common.Hash) er
 
 	v.payload = payload
 	v.hash = hash
-	v.code = PrevoteCode
+	v.code = code
 	v.verified = false
 	v.preverified = false
 	return nil

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -869,7 +869,8 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	}
 
 	// Bitmap ([]byte)
-	bitmap, err := s.Bytes()
+	bitMapAsBig := new(big.Int)
+	err = s.Decode(bitMapAsBig)
 	if err != nil {
 		return errors.Join(err, constants.ErrInvalidMessage)
 	}
@@ -887,14 +888,11 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 
 	coefficients := make([]*big.Int, 0, size)
 	for i = 0; i < size; i++ { // coefficients list
-		coeffBytes, err := s.Bytes()
-		if errors.Is(err, rlp.EOL) {
-			break
-		}
-		if err != nil {
+		coefficient := new(big.Int)
+		if err := s.Decode(coefficient); err != nil {
 			return errors.Join(err, constants.ErrInvalidMessage)
 		}
-		coefficients = append(coefficients, new(big.Int).SetBytes(coeffBytes))
+		coefficients = append(coefficients, coefficient)
 	}
 
 	if err := s.ListEnd(); err != nil { // End coefficients list
@@ -905,7 +903,7 @@ func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	}
 
 	p.signers = &types.Signers{
-		Bitmap:       (*types.Bitmap)(new(big.Int).SetBytes(bitmap)),
+		Bitmap:       (*types.Bitmap)(bitMapAsBig),
 		Coefficients: coefficients,
 	}
 	if err := p.signers.SanityCheck(); err != nil {
@@ -996,7 +994,8 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	}
 
 	// Bitmap ([]byte)
-	bitmap, err := s.Bytes()
+	bitMapAsBig := new(big.Int)
+	err = s.Decode(bitMapAsBig)
 	if err != nil {
 		return errors.Join(err, constants.ErrInvalidMessage)
 	}
@@ -1013,14 +1012,11 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 
 	coefficients := make([]*big.Int, 0, size)
 	for i = 0; i < size; i++ { // coefficients list
-		coeffBytes, err := s.Bytes()
-		if errors.Is(err, rlp.EOL) {
-			break
-		}
-		if err != nil {
+		coefficient := new(big.Int)
+		if err := s.Decode(coefficient); err != nil {
 			return errors.Join(err, constants.ErrInvalidMessage)
 		}
-		coefficients = append(coefficients, new(big.Int).SetBytes(coeffBytes))
+		coefficients = append(coefficients, coefficient)
 	}
 
 	if err := s.ListEnd(); err != nil { // End coefficients list
@@ -1031,7 +1027,7 @@ func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	}
 
 	p.signers = &types.Signers{
-		Bitmap:       (*types.Bitmap)(new(big.Int).SetBytes(bitmap)),
+		Bitmap:       (*types.Bitmap)(bitMapAsBig),
 		Coefficients: coefficients,
 	}
 	if err := p.signers.SanityCheck(); err != nil {

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -17,6 +17,7 @@
 package message
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
@@ -112,6 +113,10 @@ func (p *Propose) ValidRound() int64 {
 }
 func (p *Propose) Value() common.Hash {
 	return p.block.Hash()
+}
+
+func (p *Propose) SignatureInput() common.Hash {
+	return p.signatureInput
 }
 
 func (p *Propose) String() string {
@@ -307,6 +312,10 @@ func (p *LightProposal) ValidRound() int64 {
 
 func (p *LightProposal) Value() common.Hash {
 	return p.blockHash
+}
+
+func (p *LightProposal) SignatureInput() common.Hash {
+	return p.signatureInput
 }
 
 func (p *LightProposal) Power() *big.Int {
@@ -608,11 +617,11 @@ func (p *Precommit) String() string {
 }
 
 func newVote[
-E Prevote | Precommit,
-PE interface {
-	*E
-	Msg
-}](r int64, h uint64, value common.Hash, signer Signer, self *types.CommitteeMember, committee *types.Committee) *E {
+	E Prevote | Precommit,
+	PE interface {
+		*E
+		Msg
+	}](r int64, h uint64, value common.Hash, signer Signer, self *types.CommitteeMember, committee *types.Committee) *E {
 	code := PE(new(E)).Code()
 
 	// Pay attention that we're adding the message Code to the signature input data.
@@ -634,6 +643,7 @@ PE interface {
 	vote := E{
 		vote: vote{
 			value:   value,
+			code:    code,
 			signers: signers,
 			base: base{
 				round:          r,
@@ -764,6 +774,7 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 			vote: vote{
 				value:   representative.Value(),
 				signers: aggregateSigner,
+				code:    representative.Code(),
 				base: base{
 					height:         representative.H(),
 					round:          representative.R(),
@@ -789,87 +800,106 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 }
 
 func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
-	// The RLP structure for a vote is a list of 6 items:
-	// [Code, Round, Height, Value, Signers, Signature]
-	var decoded []any
-	if err := rlp.DecodeBytes(payload, &decoded); err != nil {
+	var s rlp.Stream
+	s.Reset(bytes.NewReader(payload), uint64(len(payload)))
+
+	if _, err := s.List(); err != nil { // Begin decoding list
+		return constants.ErrInvalidMessage
+	}
+
+	// Field 1: Code
+	code, err := s.Uint()
+	if err != nil {
 		return err
 	}
-
-	if len(decoded) != 6 {
-		return fmt.Errorf("invalid RLP for vote: expected 6 items, got %d", len(decoded))
-	}
-
-	// --- Field 1: Code ---
-	codeBytes, ok := decoded[0].([]uint8)
-	if !ok || len(codeBytes) != 1 || codeBytes[0] != PrevoteCode {
+	if code != uint64(PrevoteCode) {
 		return constants.ErrInvalidMessage
 	}
 
-	// --- Field 2: Round ---
-	roundBytes, ok := decoded[1].([]uint8)
-	if !ok {
-		return constants.ErrInvalidMessage
+	// Field 2: Round
+	round, err := s.Uint()
+	if err != nil {
+		return err
 	}
-	round := new(big.Int).SetBytes(roundBytes).Uint64()
 	if round > constants.MaxRound {
 		return constants.ErrInvalidMessage
 	}
 	p.round = int64(round)
 
-	// --- Field 3: Height ---
-	heightBytes, ok := decoded[2].([]byte)
-	if !ok {
-		return constants.ErrInvalidMessage
+	// Field 3: Height (uint64)
+	height, err := s.Uint()
+	if err != nil {
+		return err
 	}
-	height := new(big.Int).SetBytes(heightBytes).Uint64()
 	if height == 0 {
 		return constants.ErrInvalidMessage
 	}
 	p.height = height
 
-	// --- Field 4: hash ---
-	valueBytes, ok := decoded[3].([]byte)
-	if !ok {
+	// Field 4: Value (32 bytes)
+	valueBytes, err := s.Bytes()
+	if err != nil {
+		return err
+	}
+	if len(valueBytes) != common.HashLength {
 		return constants.ErrInvalidMessage
 	}
 	p.value = common.BytesToHash(valueBytes)
 
-	// --- Field 5: Signers ---
-	signersList, ok := decoded[4].([]any)
-	if !ok || len(signersList) != 2 {
-		return fmt.Errorf("invalid RLP for signers: expected a list of 2 items")
+	// Field 5: Signers (nested list [Bitmap bytes, Coefficients list])
+	if _, err := s.List(); err != nil { // Begin signers list
+		return err
 	}
 
-	bitmap, okBitmap := signersList[0].([]byte)
-	coeffsList, okCoeffs := signersList[1].([]any)
-	if !okBitmap || !okCoeffs {
-		return fmt.Errorf("invalid RLP for signers: bitmap and coefficients must be byte slices")
+	// Bitmap ([]byte)
+	bitmap, err := s.Bytes()
+	if err != nil {
+		return err
 	}
-	coefficients := make([]*big.Int, len(coeffsList))
-	for i, item := range coeffsList {
-		coeffBytes, valid := item.([]byte)
-		if !valid {
-			return fmt.Errorf("invalid RLP for coefficient item: must be a byte slice")
+
+	// Coefficients (list of []byte)
+	if _, err := s.List(); err != nil {
+		return err
+	}
+
+	var coefficients []*big.Int
+	for { // coefficients list
+		coeffBytes, err := s.Bytes()
+		if errors.Is(err, rlp.EOL) {
+			break
 		}
-		coefficients[i] = new(big.Int).SetBytes(coeffBytes)
+		if err != nil {
+			return err
+		}
+		coefficients = append(coefficients, new(big.Int).SetBytes(coeffBytes))
 	}
-	signers := &types.Signers{
+
+	if err := s.ListEnd(); err != nil { // End coefficients list
+		return err
+	}
+	if err := s.ListEnd(); err != nil { // End signers list
+		return err
+	}
+
+	p.signers = &types.Signers{
 		Bitmap:       (*types.Bitmap)(new(big.Int).SetBytes(bitmap)),
 		Coefficients: coefficients,
 	}
-	if signers.SanityCheck() != nil {
+	if err := p.signers.SanityCheck(); err != nil {
 		return constants.ErrInvalidMessage
 	}
-	p.signers = signers
 
-	// --- Field 6: Signature ---
-	sigBytes, ok := decoded[5].([]byte)
-	if !ok {
-		return constants.ErrInvalidMessage
+	// Field 6: Signature ([]byte)
+	sigBytes, err := s.Bytes()
+	if err != nil {
+		return err
 	}
 	p.signatureBytes = sigBytes
-	// Set remaining base fields
+
+	if err := s.ListEnd(); err != nil { // End outer list
+		return err
+	}
+
 	p.hash = hash
 	p.code = PrevoteCode
 	p.verified = false
@@ -887,135 +917,112 @@ func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
 	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
 }
 
-/*
-func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
-	payload, err := s.Raw()
-	if err != nil {
-		return err
-	}
-
-	encoded := &extVote{}
-	if err := rlp.DecodeBytes(payload, encoded); err != nil {
-		return err
-	}
-	if encoded.Code != PrevoteCode {
-		return constants.ErrInvalidMessage
-	}
-	if encoded.Signature == nil {
-		return constants.ErrInvalidMessage
-	}
-	if encoded.Height == 0 {
-		return constants.ErrInvalidMessage
-	}
-	if encoded.Round > constants.MaxRound {
-		return constants.ErrInvalidMessage
-	}
-	if encoded.Signers == nil || encoded.Signers.Bitmap == nil || encoded.Signers.Coefficients == nil {
-		return constants.ErrInvalidMessage
-	}
-	if encoded.Signers.SanityCheck() != nil {
-		return constants.ErrInvalidMessage
-	}
-	p.height = encoded.Height
-	p.round = int64(encoded.Round)
-	p.value = encoded.Value
-	p.signature = encoded.Signature
-	p.signers = encoded.Signers
-	p.payload = payload
-	// precompute hash and signature hash
-	p.signatureInput = VoteSignatureInput(encoded.Height, encoded.Round, PrevoteCode, encoded.Value)
-	p.hash = crypto.Hash(payload)
-	p.verified = false
-	p.preverified = false
-	return nil
-}*/
-
 func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
-	var decoded []any
-	if err := rlp.DecodeBytes(payload, &decoded); err != nil {
-		return err
-	}
+	var s rlp.Stream
+	s.Reset(bytes.NewReader(payload), uint64(len(payload)))
 
-	if len(decoded) != 6 {
-		return fmt.Errorf("invalid RLP for vote: expected 6 items, got %d", len(decoded))
+	if _, err := s.List(); err != nil { // Begin decoding list
+		return constants.ErrInvalidMessage
 	}
 
 	// Field 1: Code
-	codeBytes, ok := decoded[0].([]uint8)
-	if !ok || len(codeBytes) != 1 || codeBytes[0] != PrecommitCode {
+	code, err := s.Uint()
+	if err != nil {
+		return err
+	}
+	if code != uint64(PrecommitCode) {
 		return constants.ErrInvalidMessage
 	}
 
 	// Field 2: Round
-	roundBytes, ok := decoded[1].([]uint8)
-	if !ok {
-		return constants.ErrInvalidMessage
+	round, err := s.Uint()
+	if err != nil {
+		return err
 	}
-	round := new(big.Int).SetBytes(roundBytes).Uint64()
 	if round > constants.MaxRound {
 		return constants.ErrInvalidMessage
 	}
 	p.round = int64(round)
 
-	// Field 3: Height
-	heightBytes, ok := decoded[2].([]byte)
-	if !ok {
-		return constants.ErrInvalidMessage
+	// Field 3: Height (uint64)
+	height, err := s.Uint()
+	if err != nil {
+		return err
 	}
-	height := new(big.Int).SetBytes(heightBytes).Uint64()
 	if height == 0 {
 		return constants.ErrInvalidMessage
 	}
 	p.height = height
 
-	// Field 4: hash
-	valueBytes, ok := decoded[3].([]byte)
-	if !ok {
+	// Field 4: Value (32 bytes)
+	valueBytes, err := s.Bytes()
+	if err != nil {
+		return err
+	}
+	if len(valueBytes) != common.HashLength {
 		return constants.ErrInvalidMessage
 	}
 	p.value = common.BytesToHash(valueBytes)
 
-	// Field 5: Signers
-	signersList, ok := decoded[4].([]any)
-	if !ok || len(signersList) != 2 {
-		return fmt.Errorf("invalid RLP for signers: expected a list of 2 items")
+	// Field 5: Signers (nested list [Bitmap bytes, Coefficients list])
+	if _, err := s.List(); err != nil { // Begin signers list
+		return err
 	}
 
-	bitmap, okBitmap := signersList[0].([]byte)
-	coeffsList, okCoeffs := signersList[1].([]any)
-	if !okBitmap || !okCoeffs {
-		return fmt.Errorf("invalid RLP for signers: bitmap and coefficients must be byte slices")
+	// Bitmap ([]byte)
+	bitmap, err := s.Bytes()
+	if err != nil {
+		return err
 	}
-	coefficients := make([]*big.Int, len(coeffsList))
-	for i, item := range coeffsList {
-		coeffBytes, valid := item.([]byte)
-		if !valid {
-			return fmt.Errorf("invalid RLP for coefficient item: must be a byte slice")
+
+	// Coefficients (list of []byte)
+	if _, err := s.List(); err != nil {
+		return err
+	}
+
+	var coefficients []*big.Int
+	for { // coefficients list
+		coeffBytes, err := s.Bytes()
+		if errors.Is(err, rlp.EOL) {
+			break
 		}
-		coefficients[i] = new(big.Int).SetBytes(coeffBytes)
+		if err != nil {
+			return err
+		}
+		coefficients = append(coefficients, new(big.Int).SetBytes(coeffBytes))
 	}
-	signers := &types.Signers{
+
+	if err := s.ListEnd(); err != nil { // End coefficients list
+		return err
+	}
+	if err := s.ListEnd(); err != nil { // End signers list
+		return err
+	}
+
+	p.signers = &types.Signers{
 		Bitmap:       (*types.Bitmap)(new(big.Int).SetBytes(bitmap)),
 		Coefficients: coefficients,
 	}
-	if signers.SanityCheck() != nil {
+	if err := p.signers.SanityCheck(); err != nil {
 		return constants.ErrInvalidMessage
 	}
-	p.signers = signers
 
-	// Field 6: Signature
-	sigBytes, ok := decoded[5].([]byte)
-	if !ok {
-		return constants.ErrInvalidMessage
+	// Field 6: Signature ([]byte)
+	sigBytes, err := s.Bytes()
+	if err != nil {
+		return err
 	}
 	p.signatureBytes = sigBytes
-	p.code = PrecommitCode
-	// this hash may not be needed as this is computed in backend
+
+	if err := s.ListEnd(); err != nil { // End outer list
+		return err
+	}
+
 	p.hash = hash
-	p.payload = payload
+	p.code = PrecommitCode
 	p.verified = false
 	p.preverified = false
-
+	p.payload = payload
 	return nil
 }
 
@@ -1145,6 +1152,7 @@ func NewFakePrevote(f Fake) *Prevote {
 		vote: vote{
 			value:   f.FakeValue,
 			signers: f.FakeSigners,
+			code:    PrevoteCode,
 			base: base{
 				round:          int64(f.FakeRound),
 				height:         f.FakeHeight,
@@ -1166,6 +1174,7 @@ func NewFakePrecommit(f Fake) *Precommit {
 		vote: vote{
 			signers: f.FakeSigners,
 			value:   f.FakeValue,
+			code:    PrecommitCode,
 			base: base{
 				round:          int64(f.FakeRound),
 				height:         f.FakeHeight,

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"sort"
 	"sync"
@@ -496,6 +497,129 @@ type vote struct {
 	signatureInputOnce sync.Once
 }
 
+func (v *vote) decodeRLPPayload(code uint8, payload []byte, hash common.Hash) error {
+	s := rlpStreamPool.Get().(*rlp.Stream)
+	s.Reset(bytes.NewReader(payload), uint64(len(payload)))
+	defer rlpStreamPool.Put(s)
+
+	if _, err := s.List(); err != nil { // Begin decoding list
+		return constants.ErrInvalidMessage
+	}
+
+	// Field 1: Code
+	c, err := s.Uint()
+	if err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	if c != uint64(code) {
+		return constants.ErrInvalidMessage
+	}
+
+	// Field 2: Round
+	round, err := s.Uint()
+	if err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	if round > constants.MaxRound {
+		return constants.ErrInvalidMessage
+	}
+	v.round = int64(round)
+
+	// Field 3: Height (uint64)
+	height, err := s.Uint()
+	if err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	if height == 0 {
+		return constants.ErrInvalidMessage
+	}
+	v.height = height
+
+	// Field 4: Value (32 bytes)
+	valueBytes, err := s.Bytes()
+	if err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	if len(valueBytes) != common.HashLength {
+		return constants.ErrInvalidMessage
+	}
+	v.value = common.BytesToHash(valueBytes)
+
+	// Field 5: Signers (nested list [Bitmap bytes, Coefficients list])
+	if _, err := s.List(); err != nil { // Begin signers list
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+
+	// Bitmap ([]byte)
+	bitMapAsBig := new(big.Int)
+	err = s.Decode(bitMapAsBig)
+	if err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+
+	if bitMapAsBig.BitLen() > types.MaxAllowedSigners {
+		return constants.ErrInvalidMessage
+	}
+
+	// Coefficients (list of []byte)
+	if _, err = s.List(); err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+
+	coefficients := make([]*big.Int, 0, bitMapAsBig.BitLen())
+	for { // coefficients list
+		coefficient := new(big.Int)
+		err := s.Decode(coefficient)
+		if errors.Is(err, rlp.EOL) {
+			break
+		}
+		if err != nil {
+			return errors.Join(err, constants.ErrInvalidMessage)
+		}
+		coefficients = append(coefficients, coefficient)
+	}
+
+	if err := s.ListEnd(); err != nil { // End coefficients list
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	if err := s.ListEnd(); err != nil { // End signers list
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+
+	v.signers = &types.Signers{
+		Bitmap:       (*types.Bitmap)(bitMapAsBig),
+		Coefficients: coefficients,
+	}
+	if err := v.signers.SanityCheck(); err != nil {
+		return constants.ErrInvalidMessage
+	}
+
+	// Field 6: Signature ([]byte)
+	sigBytes, err := s.Bytes()
+	if err != nil {
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+	if len(sigBytes) != blst.BLSSignatureLength {
+		return constants.ErrInvalidMessage
+	}
+	v.signatureBytes = sigBytes
+
+	if err := s.ListEnd(); err != nil { // End outer list
+		return errors.Join(err, constants.ErrInvalidMessage)
+	}
+
+	if _, err := s.Bytes(); err != io.EOF { // Ensure no trailing data
+		return constants.ErrInvalidMessage
+	}
+
+	v.payload = payload
+	v.hash = hash
+	v.code = PrevoteCode
+	v.verified = false
+	v.preverified = false
+	return nil
+}
+
 func (v *vote) SignatureInput() common.Hash {
 	v.signatureInputOnce.Do(func() {
 		v.signatureInput = VoteSignatureInput(v.H(), uint64(v.R()), v.code, v.Value()) // #nosec
@@ -816,118 +940,7 @@ func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
 }
 
 func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
-	s := rlpStreamPool.Get().(*rlp.Stream)
-	s.Reset(bytes.NewReader(payload), uint64(len(payload)))
-	defer rlpStreamPool.Put(s)
-
-	if _, err := s.List(); err != nil { // Begin decoding list
-		return constants.ErrInvalidMessage
-	}
-
-	// Field 1: Code
-	code, err := s.Uint()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if code != uint64(PrevoteCode) {
-		return constants.ErrInvalidMessage
-	}
-
-	// Field 2: Round
-	round, err := s.Uint()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if round > constants.MaxRound {
-		return constants.ErrInvalidMessage
-	}
-	p.round = int64(round)
-
-	// Field 3: Height (uint64)
-	height, err := s.Uint()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if height == 0 {
-		return constants.ErrInvalidMessage
-	}
-	p.height = height
-
-	// Field 4: Value (32 bytes)
-	valueBytes, err := s.Bytes()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if len(valueBytes) != common.HashLength {
-		return constants.ErrInvalidMessage
-	}
-	p.value = common.BytesToHash(valueBytes)
-
-	// Field 5: Signers (nested list [Bitmap bytes, Coefficients list])
-	if _, err := s.List(); err != nil { // Begin signers list
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	// Bitmap ([]byte)
-	bitMapAsBig := new(big.Int)
-	err = s.Decode(bitMapAsBig)
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	// Coefficients (list of []byte)
-	if _, err = s.List(); err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	coefficients := make([]*big.Int, 0, bitMapAsBig.BitLen())
-	for { // coefficients list
-		coefficient := new(big.Int)
-		err := s.Decode(coefficient)
-		if errors.Is(err, rlp.EOL) {
-			break
-		}
-		if err != nil {
-			return errors.Join(err, constants.ErrInvalidMessage)
-		}
-		coefficients = append(coefficients, coefficient)
-	}
-
-	if err := s.ListEnd(); err != nil { // End coefficients list
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if err := s.ListEnd(); err != nil { // End signers list
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	p.signers = &types.Signers{
-		Bitmap:       (*types.Bitmap)(bitMapAsBig),
-		Coefficients: coefficients,
-	}
-	if err := p.signers.SanityCheck(); err != nil {
-		return constants.ErrInvalidMessage
-	}
-
-	// Field 6: Signature ([]byte)
-	sigBytes, err := s.Bytes()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if len(sigBytes) != blst.BLSSignatureLength {
-		return constants.ErrInvalidMessage
-	}
-	p.signatureBytes = sigBytes
-
-	if err := s.ListEnd(); err != nil { // End outer list
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	p.payload = payload
-	p.hash = hash
-	p.code = PrevoteCode
-	p.verified = false
-	p.preverified = false
-	return nil
+	return p.vote.decodeRLPPayload(PrevoteCode, payload, hash)
 }
 
 func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
@@ -939,118 +952,7 @@ func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
 }
 
 func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
-	s := rlpStreamPool.Get().(*rlp.Stream)
-	s.Reset(bytes.NewReader(payload), uint64(len(payload)))
-	defer rlpStreamPool.Put(s)
-
-	if _, err := s.List(); err != nil { // Begin decoding list
-		return constants.ErrInvalidMessage
-	}
-
-	// Field 1: Code
-	code, err := s.Uint()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if code != uint64(PrecommitCode) {
-		return constants.ErrInvalidMessage
-	}
-
-	// Field 2: Round
-	round, err := s.Uint()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if round > constants.MaxRound {
-		return constants.ErrInvalidMessage
-	}
-	p.round = int64(round)
-
-	// Field 3: Height (uint64)
-	height, err := s.Uint()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if height == 0 {
-		return constants.ErrInvalidMessage
-	}
-	p.height = height
-
-	// Field 4: Value (32 bytes)
-	valueBytes, err := s.Bytes()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if len(valueBytes) != common.HashLength {
-		return constants.ErrInvalidMessage
-	}
-	p.value = common.BytesToHash(valueBytes)
-
-	// Field 5: Signers (nested list [Bitmap bytes, Coefficients list])
-	if _, err := s.List(); err != nil { // Begin signers list
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	// Bitmap ([]byte)
-	bitMapAsBig := new(big.Int)
-	err = s.Decode(bitMapAsBig)
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	// Coefficients (list of []byte)
-	if _, err = s.List(); err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	coefficients := make([]*big.Int, 0, bitMapAsBig.BitLen())
-	for { // coefficients list
-		coefficient := new(big.Int)
-		err := s.Decode(coefficient)
-		if errors.Is(err, rlp.EOL) {
-			break
-		}
-		if err != nil {
-			return errors.Join(err, constants.ErrInvalidMessage)
-		}
-		coefficients = append(coefficients, coefficient)
-	}
-
-	if err := s.ListEnd(); err != nil { // End coefficients list
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if err := s.ListEnd(); err != nil { // End signers list
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	p.signers = &types.Signers{
-		Bitmap:       (*types.Bitmap)(bitMapAsBig),
-		Coefficients: coefficients,
-	}
-	if err := p.signers.SanityCheck(); err != nil {
-		return constants.ErrInvalidMessage
-	}
-
-	// Field 6: Signature ([]byte)
-	sigBytes, err := s.Bytes()
-	if err != nil {
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-	if len(sigBytes) != blst.BLSSignatureLength {
-		return constants.ErrInvalidMessage
-	}
-	p.signatureBytes = sigBytes
-
-	if err := s.ListEnd(); err != nil { // End outer list
-		return errors.Join(err, constants.ErrInvalidMessage)
-	}
-
-	p.payload = payload
-	p.hash = hash
-	p.code = PrecommitCode
-	p.verified = false
-	p.preverified = false
-	return nil
+	return p.vote.decodeRLPPayload(PrecommitCode, payload, hash)
 }
 
 func VoteSignatureInput(h uint64, r uint64, code uint8, v common.Hash) common.Hash {

--- a/consensus/tendermint/core/message/message.go
+++ b/consensus/tendermint/core/message/message.go
@@ -170,11 +170,7 @@ func NewPropose(r int64, h uint64, vr int64, block *types.Block, signer Signer, 
 	}
 }
 
-func (p *Propose) DecodeRLP(s *rlp.Stream) error {
-	payload, err := s.Raw()
-	if err != nil {
-		return err
-	}
+func (p *Propose) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	ext := &extPropose{}
 	if err := rlp.DecodeBytes(payload, ext); err != nil {
 		return err
@@ -226,10 +222,18 @@ func (p *Propose) DecodeRLP(s *rlp.Stream) error {
 	// precompute hash and signature hash
 	signaturePayload, _ := rlp.EncodeToBytes([]any{ProposalCode, ext.Round, ext.Height, ext.ValidRound, ext.IsValidRoundNil, p.block.Hash()})
 	p.signatureInput = crypto.Hash(signaturePayload)
-	p.hash = crypto.Hash(payload)
+	p.hash = hash
 	p.verified = false
 	p.preverified = false
 	return nil
+}
+
+func (p *Propose) DecodeRLP(s *rlp.Stream) error {
+	payload, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
 }
 
 func (p *Propose) Signer() common.Address {
@@ -366,11 +370,8 @@ func NewLightProposal(proposal *Propose) *LightProposal {
 	}
 }
 
-func (p *LightProposal) DecodeRLP(s *rlp.Stream) error {
-	payload, err := s.Raw()
-	if err != nil {
-		return err
-	}
+func (p *LightProposal) DecodeRLPPayload(payload []byte, hash common.Hash) error {
+
 	ext := &extLightProposal{}
 	if err := rlp.DecodeBytes(payload, ext); err != nil {
 		return err
@@ -414,10 +415,18 @@ func (p *LightProposal) DecodeRLP(s *rlp.Stream) error {
 	// precompute hash and signature hash
 	signaturePayload, _ := rlp.EncodeToBytes([]any{ProposalCode, ext.Round, ext.Height, ext.ValidRound, ext.IsValidRoundNil, p.blockHash})
 	p.signatureInput = crypto.Hash(signaturePayload)
-	p.hash = crypto.Hash(payload)
+	p.hash = hash
 	p.verified = false
 	p.preverified = false
 	return nil
+}
+
+func (p *LightProposal) DecodeRLP(s *rlp.Stream) error {
+	payload, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
 }
 
 func (p *LightProposal) Signer() common.Address {
@@ -461,13 +470,27 @@ type extVote struct {
 // TODO: would be good to do the same thing for proposal and lightproposal (to avoid code repetition)
 type vote struct {
 	signers *types.Signers
+	value   common.Hash
+	code    uint8
 	base
-	signerKeyOnce sync.Once `rlp:"-"` // ensures that the signerKey is computed only once
 
 	// signature caching
-	sigOnce        sync.Once `rlp:"-"`
-	sigErr         error     `rlp:"-"`
-	signatureBytes []byte    `rlp:"-"` // used for caching the raw sig bytes at decoding phase
+	signerKeyOnce      sync.Once `rlp:"-"` // ensures that the signerKey is computed only once
+	sigOnce            sync.Once `rlp:"-"`
+	sigErr             error     `rlp:"-"`
+	signatureBytes     []byte    `rlp:"-"` // used for caching the raw sig bytes at decoding phase
+	signatureInputOnce sync.Once `rlp:"-"`
+}
+
+func (v *vote) SignatureInput() common.Hash {
+	v.signatureInputOnce.Do(func() {
+		v.signatureInput = VoteSignatureInput(v.H(), uint64(v.R()), v.code, v.Value()) // #nosec
+	})
+	return v.signatureInput
+}
+
+func (v *vote) Value() common.Hash {
+	return v.value
 }
 
 func (v *vote) Signature() (blst.Signature, error) {
@@ -527,11 +550,6 @@ func (v *vote) PreValidate(committee *types.Committee, shouldRespectCap bool) er
 		return fmt.Errorf("invalid signers information: %w", err)
 	}
 
-	// if it is an individual signature, it cannot be 0
-	//if v.signers.Len() == 1 && v.signature.IsZero() {
-	//	return ErrInvalidIndividualVote
-	//}
-
 	maxCoefficient := v.signers.MaxCoefficient()
 	if shouldRespectCap && maxCoefficient.BitLen() > common.VoteCap {
 		return types.ErrInvalidCoefficient
@@ -553,6 +571,8 @@ func (v *vote) Validate() error {
 	if err != nil {
 		return err
 	}
+	// compute signature input
+	v.SignatureInput()
 	return v.base.Validate()
 }
 
@@ -562,16 +582,11 @@ func (v *vote) String() string {
 }
 
 type Prevote struct {
-	value common.Hash
 	vote
 }
 
 func (p *Prevote) Code() uint8 {
 	return PrevoteCode
-}
-
-func (p *Prevote) Value() common.Hash {
-	return p.value
 }
 
 func (p *Prevote) String() string {
@@ -580,16 +595,11 @@ func (p *Prevote) String() string {
 }
 
 type Precommit struct {
-	value common.Hash
 	vote
 }
 
 func (p *Precommit) Code() uint8 {
 	return PrecommitCode
-}
-
-func (p *Precommit) Value() common.Hash {
-	return p.value
 }
 
 func (p *Precommit) String() string {
@@ -598,11 +608,11 @@ func (p *Precommit) String() string {
 }
 
 func newVote[
-	E Prevote | Precommit,
-	PE interface {
-		*E
-		Msg
-	}](r int64, h uint64, value common.Hash, signer Signer, self *types.CommitteeMember, committee *types.Committee) *E {
+E Prevote | Precommit,
+PE interface {
+	*E
+	Msg
+}](r int64, h uint64, value common.Hash, signer Signer, self *types.CommitteeMember, committee *types.Committee) *E {
 	code := PE(new(E)).Code()
 
 	// Pay attention that we're adding the message Code to the signature input data.
@@ -622,8 +632,8 @@ func newVote[
 		Signature: signature.(*blst.BlsSignature),
 	})
 	vote := E{
-		value: value,
 		vote: vote{
+			value:   value,
 			signers: signers,
 			base: base{
 				round:          r,
@@ -751,8 +761,8 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 			Signature: aggregatedSignature.(*blst.BlsSignature),
 		})
 		mainAggregate := E{
-			value: representative.Value(),
 			vote: vote{
+				value:   representative.Value(),
 				signers: aggregateSigner,
 				base: base{
 					height:         representative.H(),
@@ -778,13 +788,7 @@ func AggregateVotes[E Prevote | Precommit](votes []Vote, ignoreBoundaries bool) 
 	return results
 }
 
-func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
-	// Read the raw RLP payload from the stream.
-	payload, err := s.Raw()
-	if err != nil {
-		return err
-	}
-
+func (p *Prevote) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	// The RLP structure for a vote is a list of 6 items:
 	// [Code, Round, Height, Value, Signers, Signature]
 	var decoded []any
@@ -866,14 +870,21 @@ func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
 	}
 	p.signatureBytes = sigBytes
 	// Set remaining base fields
-	//todo: defer signatureInput computation?
-	p.signatureInput = VoteSignatureInput(height, round, PrevoteCode, p.value)
-	// this hash may not be needed as this is computed in backend
-	p.hash = crypto.Hash(payload)
+	p.hash = hash
+	p.code = PrevoteCode
 	p.verified = false
 	p.preverified = false
 	p.payload = payload
 	return nil
+}
+
+func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
+	// Read the raw RLP payload from the stream.
+	payload, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
 }
 
 /*
@@ -919,15 +930,7 @@ func (p *Prevote) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }*/
 
-func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
-	// Read the raw RLP payload from the stream.
-	payload, err := s.Raw()
-	if err != nil {
-		return err
-	}
-
-	// The RLP structure for a vote is a list of 6 items:
-	// [Code, Round, Height, Value, Signers, Signature]
+func (p *Precommit) DecodeRLPPayload(payload []byte, hash common.Hash) error {
 	var decoded []any
 	if err := rlp.DecodeBytes(payload, &decoded); err != nil {
 		return err
@@ -937,13 +940,13 @@ func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("invalid RLP for vote: expected 6 items, got %d", len(decoded))
 	}
 
-	// --- Field 1: Code ---
+	// Field 1: Code
 	codeBytes, ok := decoded[0].([]uint8)
 	if !ok || len(codeBytes) != 1 || codeBytes[0] != PrecommitCode {
 		return constants.ErrInvalidMessage
 	}
 
-	// --- Field 2: Round ---
+	// Field 2: Round
 	roundBytes, ok := decoded[1].([]uint8)
 	if !ok {
 		return constants.ErrInvalidMessage
@@ -954,7 +957,7 @@ func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
 	}
 	p.round = int64(round)
 
-	// --- Field 3: Height ---
+	// Field 3: Height
 	heightBytes, ok := decoded[2].([]byte)
 	if !ok {
 		return constants.ErrInvalidMessage
@@ -965,14 +968,14 @@ func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
 	}
 	p.height = height
 
-	// --- Field 4: hash ---
+	// Field 4: hash
 	valueBytes, ok := decoded[3].([]byte)
 	if !ok {
 		return constants.ErrInvalidMessage
 	}
 	p.value = common.BytesToHash(valueBytes)
 
-	// --- Field 5: Signers ---
+	// Field 5: Signers
 	signersList, ok := decoded[4].([]any)
 	if !ok || len(signersList) != 2 {
 		return fmt.Errorf("invalid RLP for signers: expected a list of 2 items")
@@ -1000,22 +1003,29 @@ func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
 	}
 	p.signers = signers
 
-	// --- Field 6: Signature ---
+	// Field 6: Signature
 	sigBytes, ok := decoded[5].([]byte)
 	if !ok {
 		return constants.ErrInvalidMessage
 	}
 	p.signatureBytes = sigBytes
-	// Set remaining base fields
-	//todo: defer signatureInput computation?
-	p.signatureInput = VoteSignatureInput(height, round, PrecommitCode, p.value)
+	p.code = PrecommitCode
 	// this hash may not be needed as this is computed in backend
-	p.hash = crypto.Hash(payload)
+	p.hash = hash
 	p.payload = payload
 	p.verified = false
 	p.preverified = false
 
 	return nil
+}
+
+func (p *Precommit) DecodeRLP(s *rlp.Stream) error {
+	// Read the raw RLP payload from the stream.
+	payload, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return p.DecodeRLPPayload(payload, crypto.Hash(payload))
 }
 
 func VoteSignatureInput(h uint64, r uint64, code uint8, v common.Hash) common.Hash {
@@ -1098,6 +1108,10 @@ func (f Fake) SignatureInput() common.Hash                  { return f.FakeSigna
 func (f Fake) SignerKey() blst.PublicKey                    { return f.FakeSignerKey }
 func (f Fake) Verified() bool                               { return true }
 func (f Fake) PreVerified() bool                            { return true }
+func (f Fake) DecodeRLPPayload(payload []byte, _ common.Hash) error {
+	fake := &Fake{}
+	return rlp.DecodeBytes(payload, fake)
+}
 
 func NewFakePropose(f Fake) *Propose {
 	var vr int64
@@ -1128,8 +1142,8 @@ func NewFakePropose(f Fake) *Propose {
 
 func NewFakePrevote(f Fake) *Prevote {
 	prevote := &Prevote{
-		value: f.FakeValue,
 		vote: vote{
+			value:   f.FakeValue,
 			signers: f.FakeSigners,
 			base: base{
 				round:          int64(f.FakeRound),
@@ -1149,9 +1163,9 @@ func NewFakePrevote(f Fake) *Prevote {
 
 func NewFakePrecommit(f Fake) *Precommit {
 	precommit := &Precommit{
-		value: f.FakeValue,
 		vote: vote{
 			signers: f.FakeSigners,
+			value:   f.FakeValue,
 			base: base{
 				round:          int64(f.FakeRound),
 				height:         f.FakeHeight,

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -681,6 +681,7 @@ func BenchmarkDecodeVote(b *testing.B) {
 	p2pPrevote := p2p.Msg{Code: 0x12, Size: uint32(size), Payload: r}
 
 	// start the actual benchmarking
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		prevoteDec := new(Prevote)
@@ -695,27 +696,22 @@ func BenchmarkDecodeVote(b *testing.B) {
 	}
 }
 
-func BenchmarkDecodeVote2(b *testing.B) {
-	// Prepare a random hash once
+func BenchmarkDecodeVoteNew(b *testing.B) {
 	hashBytes := make([]byte, 32)
 	if _, err := rand.Read(hashBytes); err != nil {
 		b.Fatalf("failed to generate random bytes: %v", err)
 	}
 	hash := common.BytesToHash(hashBytes)
-
 	origPrevote := NewPrevote(int64(15), uint64(123345), hash, defaultSigner, testCommitteeMember, &testCommittee)
 	payload := origPrevote.Payload()
-	size := uint32(len(payload))
+	payloadHash := crypto.Hash(payload)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		reader := bytes.NewReader(payload)
-		stream := rlp.NewStream(reader, uint64(size))
-
 		var decoded Prevote
-		if err := decoded.DecodeRLP(stream); err != nil {
+		if err := decoded.DecodeRLPPayload(payload, payloadHash); err != nil {
 			b.Fatalf("DecodeRLP failed: %v", err)
 		}
 

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -690,22 +690,6 @@ func TestPrevoteDecodeRLP(t *testing.T) {
 			expectedError: constants.ErrInvalidMessage,
 		},
 		{
-			name: "coefficients list mismatched with bitmap len",
-			payload: func() []byte {
-				payload, err := rlp.EncodeToBytes([]interface{}{
-					validVote.Code,
-					validVote.Round,
-					validVote.Height,
-					validVote.Value,
-					[]interface{}{big.NewInt(1), []interface{}{big.NewInt(1), big.NewInt(1)}},
-					validVote.Signature,
-				})
-				require.NoError(t, err)
-				return payload
-			}(),
-			expectedError: constants.ErrInvalidMessage,
-		},
-		{
 			name: "coefficients list with extra items",
 			payload: func() []byte {
 				payload, err := rlp.EncodeToBytes([]interface{}{

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -91,9 +91,12 @@ func TestMessageDecode(t *testing.T) {
 		require.Equal(t, vote.R(), decoded.R())
 		require.Equal(t, vote.H(), decoded.H())
 		require.Equal(t, vote.Value(), decoded.Value())
+		require.NoError(t, decoded.Signers().Validate(&testCommittee))
 		require.Equal(t, vote.Signers().Bitmap, decoded.Signers().Bitmap)
 		require.Equal(t, vote.Signers().Coefficients, decoded.Signers().Coefficients)
-		require.Equal(t, vote.Signature(), decoded.Signature())
+		voteSignature, _ := vote.Signature()
+		decodedSignature, _ := decoded.Signature()
+		require.Equal(t, voteSignature, decodedSignature)
 	})
 	t.Run("precommit", func(t *testing.T) {
 		vote := newVote[Precommit](1, 2, common.HexToHash("0x1227"), defaultSigner, testCommitteeMember, &testCommittee)
@@ -106,9 +109,12 @@ func TestMessageDecode(t *testing.T) {
 		require.Equal(t, vote.R(), decoded.R())
 		require.Equal(t, vote.H(), decoded.H())
 		require.Equal(t, vote.Value(), decoded.Value())
+		require.NoError(t, decoded.Signers().Validate(&testCommittee))
 		require.Equal(t, vote.Signers().Bitmap, decoded.Signers().Bitmap)
 		require.Equal(t, vote.Signers().Coefficients, decoded.Signers().Coefficients)
-		require.Equal(t, vote.Signature(), decoded.Signature())
+		voteSignature, _ := vote.Signature()
+		decodedSignature, _ := decoded.Signature()
+		require.Equal(t, voteSignature, decodedSignature)
 	})
 	t.Run("propose", func(t *testing.T) {
 		header := &types.Header{Number: common.Big2}
@@ -124,7 +130,9 @@ func TestMessageDecode(t *testing.T) {
 		require.Equal(t, proposal.Value(), decoded.Value())
 		require.Equal(t, proposal.ValidRound(), decoded.ValidRound())
 		require.Equal(t, proposal.Signer(), decoded.Signer())
-		require.Equal(t, proposal.Signature(), decoded.Signature())
+		propsalSignature, _ := proposal.Signature()
+		decodedSignature, _ := decoded.Signature()
+		require.Equal(t, propsalSignature, decodedSignature)
 	})
 	t.Run("invalid propose with vr > r", func(t *testing.T) {
 		header := &types.Header{Number: common.Big2}
@@ -676,13 +684,44 @@ func BenchmarkDecodeVote(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		prevoteDec := new(Prevote)
-		if err := p2pPrevote.Decode(prevoteDec); err != nil {
+		s := rlp.NewStream(p2pPrevote.Payload, uint64(size))
+		if err := prevoteDec.DecodeRLP(s); err != nil {
 			b.Fatal("failed prevote decoding: ", err)
 		}
 		// without this re-initialization the payload gets discarded after the first iteration, making the decoding fail
 		b.StopTimer()
 		p2pPrevote.Payload = bytes.NewReader(payload)
 		b.StartTimer()
+	}
+}
+
+func BenchmarkDecodeVote2(b *testing.B) {
+	// Prepare a random hash once
+	hashBytes := make([]byte, 32)
+	if _, err := rand.Read(hashBytes); err != nil {
+		b.Fatalf("failed to generate random bytes: %v", err)
+	}
+	hash := common.BytesToHash(hashBytes)
+
+	origPrevote := NewPrevote(int64(15), uint64(123345), hash, defaultSigner, testCommitteeMember, &testCommittee)
+	payload := origPrevote.Payload()
+	size := uint32(len(payload))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		reader := bytes.NewReader(payload)
+		stream := rlp.NewStream(reader, uint64(size))
+
+		var decoded Prevote
+		if err := decoded.DecodeRLP(stream); err != nil {
+			b.Fatalf("DecodeRLP failed: %v", err)
+		}
+
+		if decoded.R() != 15 {
+			b.Fatalf("unexpected round %d", decoded.R())
+		}
 	}
 }
 

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -512,6 +512,7 @@ func TestVoteDecodeRLP_NonCanonicalUint(t *testing.T) {
 
 	// Check if the error is due to canonical integer violation
 	require.True(t, errors.Is(err, constants.ErrInvalidMessage))
+	require.True(t, errors.Is(err, rlp.ErrCanonInt))
 }
 
 func TestPrevoteDecodeRLP(t *testing.T) {
@@ -682,6 +683,22 @@ func TestPrevoteDecodeRLP(t *testing.T) {
 					validVote.Height,
 					validVote.Value,
 					[]interface{}{big.NewInt(1), []interface{}{oversized}},
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "coefficients list mismatched with bitmap len",
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(1), []interface{}{big.NewInt(1), big.NewInt(1)}},
 					validVote.Signature,
 				})
 				require.NoError(t, err)

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -371,7 +372,7 @@ func TestMessageEncodeDecode(t *testing.T) {
 	}
 }
 
-func TestPrevoteDecodeRLP_MalformedData(t *testing.T) {
+func TestPrevoteDecodeRLP(t *testing.T) {
 	key, err := blst.RandKey()
 	require.NoError(t, err)
 	signer := makeSigner(key)
@@ -401,8 +402,12 @@ func TestPrevoteDecodeRLP_MalformedData(t *testing.T) {
 		expectedError error
 	}{
 		{
+			name:          "valid vote",
+			payload:       validPayload,
+			expectedError: nil,
+		},
+		{
 			name: "extra data at the end of list",
-			// RLP encoding of: [validVote..., "extra_field"]
 			payload: func() []byte {
 				var list []interface{}
 				require.NoError(t, rlp.DecodeBytes(validPayload, &list))
@@ -415,7 +420,6 @@ func TestPrevoteDecodeRLP_MalformedData(t *testing.T) {
 		},
 		{
 			name: "too few items in list",
-			// RLP encoding of: [Code, Round, Height] (missing fields)
 			payload: func() []byte {
 				payload, err := rlp.EncodeToBytes([]interface{}{
 					validVote.Code,
@@ -429,7 +433,6 @@ func TestPrevoteDecodeRLP_MalformedData(t *testing.T) {
 		},
 		{
 			name: "wrong data type for height",
-			// RLP encoding of: [Code, Round, "not_a_height", ...]
 			payload: func() []byte {
 				payload, err := rlp.EncodeToBytes([]interface{}{
 					validVote.Code,
@@ -460,15 +463,225 @@ func TestPrevoteDecodeRLP_MalformedData(t *testing.T) {
 			}(),
 			expectedError: constants.ErrInvalidMessage,
 		},
+		// Enhanced cases for signers list
+		{
+			name: "signers list with too few sub-items",
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(1)}, // Only bitmap, missing coefficients list
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "signers list with extra sub-items",
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(1), []interface{}{big.NewInt(1)}, "extra_item"},
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "valid coefficients list encoded int size bigger than 1 byte",
+			payload: func() []byte {
+				expectedCoefficients := []*big.Int{big.NewInt(5), big.NewInt(1000)}
+				fullList := []interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(7), expectedCoefficients},
+					validVote.Signature,
+				}
+				payload, err := rlp.EncodeToBytes(fullList)
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: nil,
+		},
+		{
+			name: "coefficients list with zero value",
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(1), []interface{}{big.NewInt(0)}},
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "coefficients list with oversized BitLen",
+			payload: func() []byte {
+				oversized := new(big.Int).Lsh(big.NewInt(1), common.QuorumCap+1)
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(1), []interface{}{oversized}},
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "coefficients list mismatched with bitmap len",
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(1), []interface{}{big.NewInt(1), big.NewInt(1)}},
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "coefficients list with extra items",
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(1), []interface{}{big.NewInt(1), "extra_coeff"}},
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "coefficients list with wrong type (e.g., string instead of big.Int)",
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{big.NewInt(1), []interface{}{"not_a_bigint"}},
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "coefficients list oversized ( > MaxAllowedSigners )",
+			payload: func() []byte {
+				coeffs := make([]interface{}, types.MaxAllowedSigners+1)
+				for i := range coeffs {
+					coeffs[i] = big.NewInt(1)
+				}
+				bitmap := new(big.Int).SetBit(new(big.Int), types.MaxAllowedSigners, 1) // Oversized bitmap too
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+					validVote.Value,
+					[]interface{}{bitmap, coeffs},
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			prevote := &Prevote{}
 			err := prevote.DecodeRLPPayload(tc.payload, crypto.Hash(tc.payload))
-			require.Error(t, err, "Expected an error but got nil")
-			require.True(t, errors.Is(err, tc.expectedError), "Expected error chain to contain ErrInvalidMessage")
+			if tc.expectedError == nil {
+				require.NoError(t, err)
+			} else {
+				require.True(t, errors.Is(err, tc.expectedError), "Expected error: %v, got: %v", tc.expectedError, err)
+			}
 		})
+	}
+}
+
+func TestPrevoteDecodeRLPPayload_Concurrent(t *testing.T) {
+	key, err := blst.RandKey()
+	require.NoError(t, err)
+	signer := makeSigner(key)
+
+	signatureInputPayload, err := rlp.EncodeToBytes([]any{PrevoteCode, uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
+	require.NoError(t, err)
+	signatureInputHash := crypto.Hash(signatureInputPayload)
+	signature := signer(signatureInputHash)
+
+	validVote := extVote{
+		Code:   PrevoteCode,
+		Round:  1,
+		Height: 2,
+		Value:  common.HexToHash("0xdeadbeef"),
+		Signers: &types.Signers{
+			Bitmap:       (*types.Bitmap)(big.NewInt(1)),
+			Coefficients: []*big.Int{big.NewInt(1)},
+		},
+		Signature: signature.(*blst.BlsSignature),
+	}
+	validPayload, err := rlp.EncodeToBytes(&validVote)
+	require.NoError(t, err)
+	validHash := crypto.Hash(validPayload)
+
+	const numGoroutines = 1000
+	var wg sync.WaitGroup
+	errCh := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			prevote := &Prevote{}
+			if err := prevote.DecodeRLPPayload(validPayload, validHash); err != nil {
+				errCh <- err
+				return
+			}
+			// Basic validation to ensure no corruption
+			if prevote.Code() != PrevoteCode || prevote.R() != 1 || prevote.H() != 2 {
+				errCh <- errors.New("decoded fields mismatch")
+				return
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err, "Concurrent decoding failed")
 	}
 }
 

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -371,6 +371,107 @@ func TestMessageEncodeDecode(t *testing.T) {
 	}
 }
 
+func TestPrevoteDecodeRLP_MalformedData(t *testing.T) {
+	key, err := blst.RandKey()
+	require.NoError(t, err)
+	signer := makeSigner(key)
+
+	signatureInputPayload, err := rlp.EncodeToBytes([]any{PrevoteCode, uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
+	require.NoError(t, err)
+	signatureInputHash := crypto.Hash(signatureInputPayload)
+	signature := signer(signatureInputHash)
+
+	validVote := extVote{
+		Code:   PrevoteCode,
+		Round:  1,
+		Height: 2,
+		Value:  common.HexToHash("0xdeadbeef"),
+		Signers: &types.Signers{
+			Bitmap:       (*types.Bitmap)(big.NewInt(1)),
+			Coefficients: []*big.Int{big.NewInt(1)},
+		},
+		Signature: signature.(*blst.BlsSignature),
+	}
+	validPayload, err := rlp.EncodeToBytes(&validVote)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name          string
+		payload       []byte
+		expectedError error
+	}{
+		{
+			name: "extra data at the end of list",
+			// RLP encoding of: [validVote..., "extra_field"]
+			payload: func() []byte {
+				var list []interface{}
+				require.NoError(t, rlp.DecodeBytes(validPayload, &list))
+				list = append(list, "extra_field")
+				payload, err := rlp.EncodeToBytes(list)
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "too few items in list",
+			// RLP encoding of: [Code, Round, Height] (missing fields)
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					validVote.Height,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "wrong data type for height",
+			// RLP encoding of: [Code, Round, "not_a_height", ...]
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					"this should be a number",
+					validVote.Value,
+					validVote.Signers,
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+		{
+			name: "list where item expected",
+			payload: func() []byte {
+				payload, err := rlp.EncodeToBytes([]interface{}{
+					validVote.Code,
+					validVote.Round,
+					[]interface{}{validVote.Height}, // Height is now a list
+					validVote.Value,
+					validVote.Signers,
+					validVote.Signature,
+				})
+				require.NoError(t, err)
+				return payload
+			}(),
+			expectedError: constants.ErrInvalidMessage,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prevote := &Prevote{}
+			err := prevote.DecodeRLPPayload(tc.payload, crypto.Hash(tc.payload))
+			require.Error(t, err, "Expected an error but got nil")
+			require.True(t, errors.Is(err, tc.expectedError), "Expected error chain to contain ErrInvalidMessage")
+		})
+	}
+}
+
 // verify that aggregating same votes in different orders doesn't change the hash
 func TestMessageHash(t *testing.T) {
 	h := uint64(1)

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -3,6 +3,7 @@ package message
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -370,6 +371,146 @@ func TestMessageEncodeDecode(t *testing.T) {
 			t.Error("does not match", i)
 		}
 	}
+}
+
+func TestPrevoteDecodeCompareRLP(t *testing.T) {
+	signatureInputPayload, err := rlp.EncodeToBytes([]any{PrevoteCode, uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
+	signatureInputPayload2, err := rlp.EncodeToBytes([]any{uint64(PrevoteCode), uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
+	require.NoError(t, err)
+	signatureInputHash := crypto.Hash(signatureInputPayload)
+	signatureInputHash2 := crypto.Hash(signatureInputPayload2)
+	require.Equal(t, signatureInputHash, signatureInputHash2)
+}
+
+func TestPrevoteDecode_TrailingData(t *testing.T) {
+	key, err := blst.RandKey()
+	require.NoError(t, err)
+	signer := makeSigner(key)
+
+	signatureInputPayload, err := rlp.EncodeToBytes([]any{PrevoteCode, uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
+	require.NoError(t, err)
+	signatureInputHash := crypto.Hash(signatureInputPayload)
+	signature := signer(signatureInputHash)
+	validVote := extVote{
+		Code:   PrevoteCode,
+		Round:  1,
+		Height: 2,
+		Value:  common.HexToHash("0xdeadbeef"),
+		Signers: &types.Signers{
+			Bitmap:       (*types.Bitmap)(big.NewInt(1)),
+			Coefficients: []*big.Int{big.NewInt(1)},
+		},
+		Signature: signature.(*blst.BlsSignature),
+	}
+	validPayload, err := rlp.EncodeToBytes(&validVote)
+	require.NoError(t, err)
+	prevote := &Prevote{}
+	err = prevote.DecodeRLPPayload(validPayload, crypto.Hash(validPayload))
+	require.NoError(t, err)
+
+	tweakedPayload := append(validPayload, []byte{0xca, 0xfe}...)
+	prevote = &Prevote{}
+	err = prevote.DecodeRLPPayload(tweakedPayload, crypto.Hash(tweakedPayload))
+	require.Error(t, err)
+}
+
+func TestVoteDecodeRLP_NonCanonicalUint(t *testing.T) {
+	// Create a valid extVote structure
+	key, err := blst.RandKey()
+	require.NoError(t, err)
+	signer := makeSigner(key)
+
+	signatureInputPayload, err := rlp.EncodeToBytes([]any{PrevoteCode, uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
+	require.NoError(t, err)
+	signatureInputHash := crypto.Hash(signatureInputPayload)
+	signature := signer(signatureInputHash)
+
+	validVote := extVote{
+		Code:   PrevoteCode,
+		Round:  1,
+		Height: 2,
+		Value:  common.HexToHash("0xdeadbeef"),
+		Signers: &types.Signers{
+			Bitmap:       (*types.Bitmap)(big.NewInt(1)),
+			Coefficients: []*big.Int{big.NewInt(1)},
+		},
+		Signature: signature.(*blst.BlsSignature),
+	}
+
+	// Encode the valid vote to RLP
+	validPayload, err := rlp.EncodeToBytes(validVote)
+	if err != nil {
+		t.Fatalf("failed to encode valid vote: %v", err)
+	}
+
+	// Parse the valid payload to extract individual field RLPs
+	s := rlp.NewStream(bytes.NewReader(validPayload), 0)
+	_, err = s.List()
+	if err != nil {
+		t.Fatalf("failed to start list: %v", err)
+	}
+
+	var fieldRLPs [][]byte
+	for {
+		raw, err := s.Raw()
+		if err == rlp.EOL {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed to read raw field: %v", err)
+		}
+		fieldRLPs = append(fieldRLPs, raw)
+	}
+
+	if err := s.ListEnd(); err != nil {
+		t.Fatalf("failed to end list: %v", err)
+	}
+
+	// Tamper the first field (Code) with non-canonical encoding: 0x820001 for value 1
+	// now instead of 0x01 we have 0x820001 which is non-canonical for uint, 82 for short byte array of length 2
+	tamperedCodeRLP, err := hex.DecodeString("820001")
+	if err != nil {
+		t.Fatalf("failed to decode hex: %v", err)
+	}
+	fieldRLPs[0] = tamperedCodeRLP
+
+	// Rebuild the content bytes
+	var content bytes.Buffer
+	for _, f := range fieldRLPs {
+		content.Write(f)
+	}
+	contentBytes := content.Bytes()
+	contentLen := len(contentBytes)
+
+	// Compute the list header
+	var header []byte
+	// up to 55 bytes, single byte prefix 0xc0 + length
+	if contentLen < 56 {
+		header = []byte{0xc0 + byte(contentLen)}
+	} else {
+		// more than 55 bytes, prefix 0xf7 + len(contentLen) followed by len in big endian
+		lenBig := big.NewInt(int64(contentLen))
+		lenBytes := lenBig.Bytes()
+		headerLen := len(lenBytes)
+		header = make([]byte, 1+headerLen)
+		header[0] = 0xf7 + byte(headerLen)
+		copy(header[1:], lenBytes)
+	}
+
+	// Build tampered payload
+	var tamperedPayload bytes.Buffer
+	tamperedPayload.Write(header)
+	tamperedPayload.Write(contentBytes)
+
+	// Attempt to decode the tampered payload into a Prevote
+	prevote := &Prevote{}
+	err = prevote.DecodeRLPPayload(tamperedPayload.Bytes(), common.Hash{})
+	if err == nil {
+		t.Fatal("expected decoding error for non-canonical uint, but got nil")
+	}
+
+	// Check if the error is due to canonical integer violation
+	require.True(t, errors.Is(err, constants.ErrInvalidMessage))
 }
 
 func TestPrevoteDecodeRLP(t *testing.T) {

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -647,7 +647,7 @@ func TestPrevoteDecodeRLP(t *testing.T) {
 					validVote.Round,
 					validVote.Height,
 					validVote.Value,
-					[]interface{}{big.NewInt(7), expectedCoefficients},
+					[]interface{}{big.NewInt(3), expectedCoefficients},
 					validVote.Signature,
 				}
 				payload, err := rlp.EncodeToBytes(fullList)
@@ -938,6 +938,142 @@ func FuzzFromPayload(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed []byte) {
 		var p Prevote
 		rlp.Decode(bytes.NewReader(seed), &p)
+	})
+}
+
+func FuzzVoteDecode(f *testing.F) {
+	key, err := blst.RandKey()
+	require.NoError(f, err)
+	pubKey := key.PublicKey()
+	signer := makeSigner(key)
+
+	dummyCommittee := &types.Committee{
+		Members: []types.CommitteeMember{
+			{Index: 0, Address: common.Address{0x01}, VotingPower: big.NewInt(1), ConsensusKey: pubKey},
+		},
+	}
+
+	// Seed1: Valid simple vote with real signature
+	signatureInputPayload, err := rlp.EncodeToBytes([]any{PrevoteCode, uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
+	require.NoError(f, err)
+	signatureInputHash := crypto.Hash(signatureInputPayload)
+	signature := signer(signatureInputHash)
+	sigBytes := signature.Marshal()
+	bitmapBytes := big.NewInt(1).Bytes()
+	coeffsRLP, err := rlp.EncodeToBytes([]*big.Int{big.NewInt(1)})
+	require.NoError(f, err)
+	valueBytes := common.HexToHash("0xdeadbeef").Bytes()
+	f.Add(PrevoteCode, uint64(1), uint64(2), valueBytes, bitmapBytes, coeffsRLP, sigBytes)
+
+	// Seed2: Valid with signers, should fail on prevalidate due to mismatch in coefficient and bitmap
+	valueBytes2 := common.HexToHash("0x02").Bytes()
+	bitmapBytes2 := big.NewInt(3).Bytes()
+	coeffsRLP2, err := rlp.EncodeToBytes([]*big.Int{big.NewInt(1)})
+	require.NoError(f, err)
+	f.Add(PrevoteCode, uint64(5), uint64(10), valueBytes2, bitmapBytes2, coeffsRLP2, sigBytes) // reuse sig, but fuzzer will vary
+
+	// Seed: Edge - max round, zero value, empty sig (invalid)
+	valueBytes3 := common.Hash{}.Bytes()
+	bitmapBytes3 := big.NewInt(0).Bytes()
+	coeffsRLP3 := []byte{}
+	f.Add(PrevoteCode, uint64(constants.MaxRound), uint64(0), valueBytes3, bitmapBytes3, coeffsRLP3, []byte{})
+
+	// Seed: Non-canonical tamper (e.g., leading zero in code, but fuzzer will mutate)
+	valueBytes4 := common.Hash{0x01}.Bytes()
+	bitmapBytes4 := big.NewInt(1).Bytes()
+	coeffsRLP4, err := rlp.EncodeToBytes([]*big.Int{big.NewInt(1)})
+	require.NoError(f, err)
+	f.Add(uint8(0x00), uint64(0), uint64(1), valueBytes4, bitmapBytes4, coeffsRLP4, make([]byte, blst.BLSSignatureLength))
+
+	// More seeds: Empty-like, random junk
+	valueBytes5 := common.Hash{}.Bytes()
+	bitmapBytes5 := big.NewInt(0).Bytes()
+	coeffsRLP5 := []byte{}
+	f.Add(uint8(0), uint64(0), uint64(0), valueBytes5, bitmapBytes5, coeffsRLP5, []byte{})
+	valueBytes6 := bytes.Repeat([]byte{0xff}, 32)
+	bitmapBytes6 := big.NewInt(1 << 32).Bytes()
+	coeffsRLP6, err := rlp.EncodeToBytes([]*big.Int{new(big.Int).SetBytes(bytes.Repeat([]byte{0xff}, 100))})
+	require.NoError(f, err)
+	sigBytes6 := bytes.Repeat([]byte{0xff}, 1000)
+	f.Add(uint8(255), uint64(1<<63-1), uint64(1), valueBytes6, bitmapBytes6, coeffsRLP6, sigBytes6)
+
+	f.Fuzz(func(t *testing.T, code uint8, round uint64, height uint64, valueBytes []byte, bitmapBytes []byte, coeffsRLP []byte, sigBytes []byte) {
+		if len(valueBytes) != common.HashLength {
+			return
+		}
+		value := common.BytesToHash(valueBytes)
+
+		// Construct extVote from fuzzed inputs (structured)
+		var coeffs []*big.Int
+		if err := rlp.DecodeBytes(coeffsRLP, &coeffs); err != nil {
+			return
+		}
+		ext := extVote{
+			Code:   code,
+			Round:  round,
+			Height: height,
+			Value:  value,
+			Signers: &types.Signers{
+				Bitmap:       (*types.Bitmap)(new(big.Int).SetBytes(bitmapBytes)),
+				Coefficients: coeffs,
+			},
+			Signature: signature.(*blst.BlsSignature), // Default in case of bad input
+		}
+		sig, err := blst.SignatureFromBytes(sigBytes)
+		if err == nil {
+			ext.Signature = sig.(*blst.BlsSignature)
+		}
+
+		// Encode to bytes (if fails, skip - bad input)
+		payload, err := rlp.EncodeToBytes(ext)
+		if err != nil {
+			return // Fuzzer will try other mutations
+		}
+		hash := crypto.Hash(payload)
+
+		// Decode
+		prevote := &Prevote{}
+		err = prevote.DecodeRLPPayload(payload, hash)
+
+		// Check return value
+		if err == nil {
+			// Success: Check invariants
+			if prevote.Code() != PrevoteCode {
+				t.Errorf("Invariant failed: wrong code %d", prevote.Code())
+			}
+			if prevote.H() == 0 {
+				t.Errorf("Invariant failed: zero height")
+			}
+			if prevote.Value() == (common.Hash{}) && len(payload) > 10 { // Arbitrary threshold for non-trivial input
+				t.Errorf("Invariant failed: zero value on non-empty input")
+			}
+
+			// Call further methods, ensure no panic
+			preErr := prevote.PreValidate(dummyCommittee, true)
+			if preErr == nil && prevote.Signers().Len() == 0 {
+				t.Errorf("PreValidate succeeded but zero signers")
+			}
+
+			if preErr == nil { // validate only if prevalidate passed
+				valErr := prevote.Validate()
+				if valErr == nil && prevote.Signers().Len() == 0 {
+					t.Errorf("Validate succeeded but zero signers")
+				}
+			}
+
+			// Round-trip: Re-encode and compare (canonical check)
+			reEncoded, reErr := rlp.EncodeToBytes(extVote{
+				Code:      prevote.Code(),
+				Round:     uint64(prevote.R()),
+				Height:    prevote.H(),
+				Value:     prevote.Value(),
+				Signers:   prevote.Signers(),
+				Signature: ext.Signature, // Reuse original sig for comparison
+			})
+			if reErr == nil && !bytes.Equal(payload, reEncoded) {
+				t.Errorf("Round-trip failed: original %x != re-encoded %x", payload, reEncoded)
+			}
+		}
 	})
 }
 

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/autonity/autonity/core/types"
 	"github.com/autonity/autonity/crypto"
 	"github.com/autonity/autonity/crypto/blst"
-	"github.com/autonity/autonity/p2p"
 	"github.com/autonity/autonity/rlp"
 )
 
@@ -91,6 +90,7 @@ func TestMessageDecode(t *testing.T) {
 		require.Equal(t, vote.R(), decoded.R())
 		require.Equal(t, vote.H(), decoded.H())
 		require.Equal(t, vote.Value(), decoded.Value())
+		require.NoError(t, decoded.PreValidate(&testCommittee, false))
 		require.NoError(t, decoded.Signers().Validate(&testCommittee))
 		require.Equal(t, vote.Signers().Bitmap, decoded.Signers().Bitmap)
 		require.Equal(t, vote.Signers().Coefficients, decoded.Signers().Coefficients)
@@ -109,6 +109,7 @@ func TestMessageDecode(t *testing.T) {
 		require.Equal(t, vote.R(), decoded.R())
 		require.Equal(t, vote.H(), decoded.H())
 		require.Equal(t, vote.Value(), decoded.Value())
+		require.NoError(t, decoded.PreValidate(&testCommittee, false))
 		require.NoError(t, decoded.Signers().Validate(&testCommittee))
 		require.Equal(t, vote.Signers().Bitmap, decoded.Signers().Bitmap)
 		require.Equal(t, vote.Signers().Coefficients, decoded.Signers().Coefficients)
@@ -675,50 +676,16 @@ func BenchmarkDecodeVote(b *testing.B) {
 	}
 	hash := common.BytesToHash(hashBytes)
 	prevote := NewPrevote(int64(15), uint64(123345), hash, defaultSigner, testCommitteeMember, &testCommittee)
-
-	// create p2p prevote
 	payload := prevote.Payload()
-	r := bytes.NewReader(payload)
-	size := len(payload)
-	p2pPrevote := p2p.Msg{Code: 0x12, Size: uint32(size), Payload: r}
+	payloadHash := crypto.Hash(payload)
 
 	// start the actual benchmarking
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		prevoteDec := new(Prevote)
-		s := rlp.NewStream(p2pPrevote.Payload, uint64(size))
-		if err := prevoteDec.DecodeRLP(s); err != nil {
+		if err := prevoteDec.DecodeRLPPayload(payload, payloadHash); err != nil {
 			b.Fatal("failed prevote decoding: ", err)
-		}
-		// without this re-initialization the payload gets discarded after the first iteration, making the decoding fail
-		b.StopTimer()
-		p2pPrevote.Payload = bytes.NewReader(payload)
-		b.StartTimer()
-	}
-}
-
-func BenchmarkDecodeVoteNew(b *testing.B) {
-	hashBytes := make([]byte, 32)
-	if _, err := rand.Read(hashBytes); err != nil {
-		b.Fatalf("failed to generate random bytes: %v", err)
-	}
-	hash := common.BytesToHash(hashBytes)
-	origPrevote := NewPrevote(int64(15), uint64(123345), hash, defaultSigner, testCommitteeMember, &testCommittee)
-	payload := origPrevote.Payload()
-	payloadHash := crypto.Hash(payload)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		var decoded Prevote
-		if err := decoded.DecodeRLPPayload(payload, payloadHash); err != nil {
-			b.Fatalf("DecodeRLP failed: %v", err)
-		}
-
-		if decoded.R() != 15 {
-			b.Fatalf("unexpected round %d", decoded.R())
 		}
 	}
 }

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -462,14 +462,16 @@ func TestMessageHash(t *testing.T) {
 // helper to recompute hash since in production code it is computed only once at decoding and cached
 // therefore modifying internals of a vote doesn't lead to the cached hash to change
 func recomputeHash(vote Vote) common.Hash {
-	payload, _ := rlp.EncodeToBytes(extVote{
-		Code:      vote.Code(),
-		Round:     uint64(vote.R()), // #nosec
-		Height:    vote.H(),
-		Value:     vote.Value(),
-		Signers:   vote.Signers(),
-		Signature: vote.Signature().(*blst.BlsSignature),
-	})
+	extvote := extVote{
+		Code:    vote.Code(),
+		Round:   uint64(vote.R()), // #nosec
+		Height:  vote.H(),
+		Value:   vote.Value(),
+		Signers: vote.Signers(),
+	}
+	sig, _ := vote.Signature()
+	extvote.Signature = sig.(*blst.BlsSignature)
+	payload, _ := rlp.EncodeToBytes(extvote)
 	return crypto.Hash(payload)
 }
 

--- a/consensus/tendermint/core/message/message_test.go
+++ b/consensus/tendermint/core/message/message_test.go
@@ -375,6 +375,7 @@ func TestMessageEncodeDecode(t *testing.T) {
 
 func TestPrevoteDecodeCompareRLP(t *testing.T) {
 	signatureInputPayload, err := rlp.EncodeToBytes([]any{PrevoteCode, uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
+	require.NoError(t, err)
 	signatureInputPayload2, err := rlp.EncodeToBytes([]any{uint64(PrevoteCode), uint64(1), uint64(2), common.HexToHash("0xdeadbeef")})
 	require.NoError(t, err)
 	signatureInputHash := crypto.Hash(signatureInputPayload)

--- a/consensus/tendermint/core/precommit_test.go
+++ b/consensus/tendermint/core/precommit_test.go
@@ -188,7 +188,8 @@ func TestHandlePrecommit(t *testing.T) {
 					t.Fatal("Commit called with round different than precommit seal")
 				}
 
-				expectedQuorumCertificate := types.NewAggregateSignature(msg.Signature().Copy(), msg.Signers().Copy())
+				msgSig, _ := msg.Signature()
+				expectedQuorumCertificate := types.NewAggregateSignature(msgSig.Copy(), msg.Signers().Copy())
 				if !reflect.DeepEqual(expectedQuorumCertificate, quorumCertificate) {
 					t.Fatal("Commit called with wrong seal")
 				}

--- a/consensus/tendermint/core/upon_condition_test.go
+++ b/consensus/tendermint/core/upon_condition_test.go
@@ -1195,7 +1195,9 @@ func TestQuorumPrecommit(t *testing.T) {
 	quorumCertificateSigners := quorumPrecommitMsg.Signers().Copy()
 	quorumCertificateSigners.Merge(precommit.Signers().Copy())
 
-	quorumCertificateSignature := blst.AggregateSignatures([]blst.Signature{quorumPrecommitMsg.Signature(), precommit.Signature()})
+	quorumSig, _ := quorumPrecommitMsg.Signature()
+	precommitSig, _ := precommit.Signature()
+	quorumCertificateSignature := blst.AggregateSignatures([]blst.Signature{quorumSig, precommitSig})
 
 	backendMock.EXPECT().Commit(proposal.Block(), e.curRound, gomock.Any()).Do(
 		func(proposalBlock *types.Block, round int64, quorumCertificate *types.AggregateSignature) {

--- a/core/types/signers.go
+++ b/core/types/signers.go
@@ -77,7 +77,7 @@ func (s *Signers) SanityCheck() error {
 	if s.Bitmap.Len() > MaxAllowedSigners {
 		return fmt.Errorf("invalid Bitmap length: %d", s.Bitmap.Len())
 	}
-	if len(s.Coefficients) == 0 || len(s.Coefficients) > MaxAllowedSigners || len(s.Coefficients) > s.Bitmap.Len() {
+	if len(s.Coefficients) == 0 || len(s.Coefficients) > MaxAllowedSigners || len(s.Coefficients) != s.Bitmap.Len() {
 		return fmt.Errorf("invalid Coefficient length: %d Bitmap length: %d", len(s.Coefficients), s.Bitmap.Len())
 	}
 	for _, coefficient := range s.Coefficients {

--- a/core/types/signers.go
+++ b/core/types/signers.go
@@ -77,7 +77,7 @@ func (s *Signers) SanityCheck() error {
 	if s.Bitmap.Len() > MaxAllowedSigners {
 		return fmt.Errorf("invalid Bitmap length: %d", s.Bitmap.Len())
 	}
-	if len(s.Coefficients) == 0 || len(s.Coefficients) > MaxAllowedSigners {
+	if len(s.Coefficients) == 0 || len(s.Coefficients) > MaxAllowedSigners || len(s.Coefficients) > s.Bitmap.Len() {
 		return fmt.Errorf("invalid Coefficient length: %d Bitmap length: %d", len(s.Coefficients), s.Bitmap.Len())
 	}
 	for _, coefficient := range s.Coefficients {

--- a/core/types/signers.go
+++ b/core/types/signers.go
@@ -77,7 +77,7 @@ func (s *Signers) SanityCheck() error {
 	if s.Bitmap.Len() > MaxAllowedSigners {
 		return fmt.Errorf("invalid Bitmap length: %d", s.Bitmap.Len())
 	}
-	if len(s.Coefficients) == 0 || len(s.Coefficients) > MaxAllowedSigners || len(s.Coefficients) != s.Bitmap.Len() {
+	if len(s.Coefficients) == 0 || len(s.Coefficients) > MaxAllowedSigners {
 		return fmt.Errorf("invalid Coefficient length: %d Bitmap length: %d", len(s.Coefficients), s.Bitmap.Len())
 	}
 	for _, coefficient := range s.Coefficients {

--- a/core/types/signers.go
+++ b/core/types/signers.go
@@ -77,8 +77,8 @@ func (s *Signers) SanityCheck() error {
 	if s.Bitmap.Len() > MaxAllowedSigners {
 		return fmt.Errorf("invalid Bitmap length: %d", s.Bitmap.Len())
 	}
-	if len(s.Coefficients) == 0 || len(s.Coefficients) > MaxAllowedSigners {
-		return fmt.Errorf("invalid Coefficient length: %d", len(s.Coefficients))
+	if len(s.Coefficients) == 0 || len(s.Coefficients) > MaxAllowedSigners || len(s.Coefficients) > s.Bitmap.Len() {
+		return fmt.Errorf("invalid Coefficient length: %d Bitmap length: %d", len(s.Coefficients), s.Bitmap.Len())
 	}
 	for _, coefficient := range s.Coefficients {
 		// coefficients cannot be nil


### PR DESCRIPTION
-  Defer Signature computation to aggregator.
-  Introduced workers in aggregator to concurrently compute signerKey and Signature as soon as a vote is received.
-  Reuse backand hash in vote decoding
-  Defer SignatureInput computation to validate stage
-  Refactoring in aggregator